### PR TITLE
Give correct path for cmake configuration

### DIFF
--- a/projects/buildsystem/using.md
+++ b/projects/buildsystem/using.md
@@ -74,16 +74,16 @@ you can use the following approaches to bring up a user-interface for option con
  * A `ncurses` based configuration:
 
 ```sh
-ccmake ..
+ccmake .
 ```
 
  * Graphical configuration:
 
 ```sh
-cmake-gui ..
+cmake-gui .
 ```
 
-In both cases the path `..` should resolve to the same directory used in the build configuration.
+In both cases the path `.` should resolve to the same directory used in the build configuration.
 
 #### Changing option values
 


### PR DESCRIPTION
The cmake command needs to be given a path to the build directory, not to the source directory.