### PR TITLE
admin role: Luke has stepped down

### DIFF
--- a/processes/roles.md
+++ b/processes/roles.md
@@ -55,7 +55,6 @@ You can nominate someone for a role by emailing the chair of the TSC.
    Current members are:
 
   - Peter Chubb, CSIRO's Data61
-  - Luke Mondy, CSIRO's Data61
 
   &nbsp;
 


### PR DESCRIPTION
Luke has left D61 for greener pastures and stepped down from the foundation admin role, at least for now.