### PR TITLE
github: allow manual build kick-off

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
   schedule:
     - cron: '7 3 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -36,7 +37,8 @@ jobs:
         path: site.tar
 
   deploy:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' ||
+            github.event_name == 'workflow_dispatch' }}
     needs: build
     name: 'Deploy'
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow dispatch event lets you manually kick off a website build
and deploy cycle. Useful for when one of the dependencies has changed
and you don't want to wait for the schedule to pick it up.
