### PR TITLE
bundler: force local install of ruby gems

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,8 @@
+# Copyright 2021 seL4 Foundation
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_DISABLE_SHARED_GEMS: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site/
 _repos/
 projects/virtualization/docs/api/
 .jekyll-cache/
+vendor/


### PR DESCRIPTION
Make sure that the Makefile does not try to install global gems, because this only works with super user privileges.

This also fixes seL4/sel4webserver-manifest#2
