### PR TITLE
sel4proj update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,6 @@
 title: seL4 docs
 
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 git_repo: https://github.com/SEL4PROJ/docs
 url: "https://docs.sel4.systems"

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ title: seL4 docs
 
 baseurl: "" # the subpath of your site, e.g. /blog
 
-git_repo: https://github.com/SEL4PROJ/docs
+git_repo: https://github.com/seL4/docs
 url: "https://docs.sel4.systems"
 static_url: "https://docs.sel4.systems"
 google_analytics: UA-117737473-2

--- a/content_collections/_dependencies/camkes.md
+++ b/content_collections/_dependencies/camkes.md
@@ -46,6 +46,6 @@ sudo apt-get install qemu-kvm
 
 ##### For Debian Stretch or later
 
-The dependencies listed in our docker files [repository](https://github.com/SEL4PROJ/seL4-CAmkES-L4v-dockerfiles) will work for a Debian installation. You can refer to this repository for an up-to-date list of base build dependencies. Specifically refer to the dependencies listed in the:
+The dependencies listed in our docker files [repository](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles) will work for a Debian installation. You can refer to this repository for an up-to-date list of base build dependencies. Specifically refer to the dependencies listed in the:
 
-* [CAmkES Dockerfile](https://github.com/SEL4PROJ/seL4-CAmkES-L4v-dockerfiles/blob/master/camkes.dockerfile)
+* [CAmkES Dockerfile](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/blob/master/camkes.dockerfile)

--- a/content_collections/_releases/camkes/camkes-3.2.0.md
+++ b/content_collections/_releases/camkes/camkes-3.2.0.md
@@ -24,7 +24,7 @@ Using seL4 version 8.0.0
 
     See the following ADL files for examples of Struct and
     Attribute behavior.
-    <https://github.com/SEL4PROJ/rumprun/blob/master/platform/sel4/camkes/rumprun.camkes>
+    <https://github.com/seL4/rumprun/blob/master/platform/sel4/camkes/rumprun.camkes>
     <https://github.com/seL4/camkes/tree/master/apps/structs>
     <https://github.com/seL4/camkes/tree/master/apps/attributes>
 

--- a/projects/buildsystem/incorporating.md
+++ b/projects/buildsystem/incorporating.md
@@ -237,6 +237,6 @@ the system. This can only be used once in a project and does the following:
 
 #### Other provided helpers
 
-Projects such as [Camkes](/CAmkES), the [Camkes x86 VMM](/CAmkESVM), and [Rumprun](https://github.com/SEL4PROJ/rumprun-sel4-demoapps) may provide additional helper functions
+Projects such as [Camkes](/CAmkES), the [Camkes x86 VMM](/CAmkESVM), and [Rumprun](https://github.com/seL4/rumprun-sel4-demoapps) may provide additional helper functions
 to allow applications to configure themselves. Generally helper scripts will be called some variant
 of `helpers.cmake`, and should be included in any CMake scripts that use them.

--- a/projects/camkes-vm/index.md
+++ b/projects/camkes-vm/index.md
@@ -313,8 +313,8 @@ natively, and run the command `lspci -vv`.
 
 ## Configuring a Linux kernel build
 
-We provide a custom kernel image with our CAmkES VM project, found [here](https://github.com/SEL4PROJ/camkes-vm-linux/tree/master/images/kernel).
-This kernel image is produced from building Linux 4.8.16, specifically configured with the following [.config file](https://github.com/SEL4PROJ/camkes-vm-linux/tree/master/linux_configs/4.8.16).
+We provide a custom kernel image with our CAmkES VM project, found [here](https://github.com/seL4/camkes-vm-linux/tree/master/images/kernel).
+This kernel image is produced from building Linux 4.8.16, specifically configured with the following [.config file](https://github.com/seL4/camkes-vm-linux/tree/master/linux_configs/4.8.16).
 
 However you may decide to build your own Linux kernel image (which may be a different version). When doing so, it is important to ensure the build is configured with the following Kbuild settings:
 

--- a/projects/camkes/seL4SharedDataWithCaps.md
+++ b/projects/camkes/seL4SharedDataWithCaps.md
@@ -17,7 +17,7 @@ which require the VMM to map memory backing a dataport into the VM's
 address space - an operation which requires caps to the frames.
 
 The templates and connector definition for `seL4SharedDataWithCaps` is in
-[global-components](https://github.com/SEL4PROJ/global-components).
+[global-components](https://github.com/seL4/global-components).
 
 For an example of this connector in action, see the
 [CAmkES VM](https://github.com/seL4/camkes-vm-examples/blob/master/apps/x86/optiplex9020/optiplex9020.camkes#L46).

--- a/projects/dockerfiles/index.md
+++ b/projects/dockerfiles/index.md
@@ -31,7 +31,7 @@ sudo usermod -aG docker $(whoami)
 To get a running build environment for seL4 and Camkes, run:
 
 ```bash
-git clone https://github.com/SEL4PROJ/seL4-CAmkES-L4v-dockerfiles.git
+git clone https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles.git
 cd seL4-CAmkES-L4v-dockerfiles
 make user
 ```
@@ -109,7 +109,7 @@ The CI software always uses the `latest` docker image, but images are also tagge
 
 ## More information
 
-You can find the dockerfiles and supporting Makefile [here](https://github.com/SEL4PROJ/seL4-CAmkES-L4v-dockerfiles)
+You can find the dockerfiles and supporting Makefile [here](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles)
 
 Pull-requests and issues are [welcome](https://docs.sel4.systems/Contributing).
     

--- a/projects/user_libs/index.md
+++ b/projects/user_libs/index.md
@@ -18,10 +18,10 @@ We have four major collections of libraries developed in house:
 - **[util_libs](https://github.com/seL4/util_libs)**: OS
       independent libs that were started before the open sourcing of
       seL4
-- **[seL4_projects_libs](https://github.com/SEL4PROJ/seL4_projects_libs)**:
+- **[seL4_projects_libs](https://github.com/seL4/seL4_projects_libs)**:
       seL4 specific libs that were started after the open sourcing of
       seL4 - new libraries should go here.
-- **[projects_libs](https://github.com/SEL4PROJ/projects_libs)**:
+- **[projects_libs](https://github.com/seL4/projects_libs)**:
       OS independent libs that were started after the open source of
       seL4 - new OS independent libs should go here.
 


### PR DESCRIPTION
* config: remove duplicate key ("url:" was set twice. This removes the empty version.)
* Update URLs and examples for everything that was moved from seL4proj to the seL4 org.