### PR TITLE
footer: make sure edit URL contains no newlines

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,13 +40,9 @@ This file was inspired by the file of the same name in the minima template.
 Collection pages set their absolute path variable relative to the site.collections_dir property.
 To provide a URL to this page in the GitHub repository, we need to amend the path.
 {% endcomment %}
-{% capture src_path %}
-{% if page.collection %}
-{{site.collections_dir}}/{{page.path}}
-{% else %}
-{{page.path}}
-{% endif %}
-{% endcapture %}
+{%- capture src_path -%}
+{% if page.collection %}{{site.collections_dir}}/{{page.path}}{% else %}{{page.path}}{% endif %}
+{%- endcapture -%}
       <a href="{{site.git_repo | append: '/blob/master/' | append: src_path}}">View page on GitHub</a>
       <br />
       <a href="{{site.git_repo | append: '/edit/master/' | append: src_path}}">Edit page on GitHub</a>


### PR DESCRIPTION
The {% capture %} expression previously generated a file path and therefore URL that had newline characters in it. Most web browsers just ignore these, but it's not strictly valid HTML and some link checkers choke on it.
