### PR TITLE
fix Robigalia link

### DIFF
--- a/CommunityProjects.md
+++ b/CommunityProjects.md
@@ -27,7 +27,7 @@ process of being ported to seL4:
 - C
 - [Ivory](http://ivorylang.org/ivory-introduction.html)
 - Rust:
-  - The [Robigalia](https://robigalia.org/) project:
+  - The [Robigalia](https://gitlab.com/robigalia/) project:
       building a robust Rust ecosystem around seL4
   - [ferros](https://github.com/auxoncorp/ferros):
       A Rust-based userland which also adds compile-time assurances to seL4 development.


### PR DESCRIPTION
The main site seems to have disappeared, link to the gitlab collection instead.