### PR TITLE
host-deps: add LaTeX dependencies for manual

### DIFF
--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -56,6 +56,12 @@ sudo apt-get install qemu-system-arm qemu-system-x86 qemu-system-misc
 sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 ```
 
+To build the seL4 manual, you will need the following LaTeX packages:
+
+```sh
+sudo apt-get install texlive texlive-latex-extra texlive-fonts-extra
+```
+
 #### Debian
 
 ##### For Debian Stretch or later
@@ -64,6 +70,7 @@ The dependencies listed in our docker files [repository](https://github.com/seL4
 
 * [Base Tools Dockerfile](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/blob/master/base_tools.dockerfile)
 * [seL4 Dockerfile](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/blob/master/sel4.dockerfile)
+* [LaTeX](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/blob/master/scripts/apply-tex.sh)
 
 The version of `cmake` in Debian *stretch* is too old to build seL4 projects (*buster* and later are OK).  If you are on *stretch*, install `cmake` from stretch-backports:
 


### PR DESCRIPTION
The seL4 manual requires a few extra latex packages, in particular texlive-latex-extra and texlive-fonts-extra.