### PR TITLE
update maintained repo list

### DIFF
--- a/_data/maintained.yml
+++ b/_data/maintained.yml
@@ -30,8 +30,6 @@ github:
       - camkes-vm-examples
       - camkes-vm-examples-manifest
       - camkes-vm-linux
-      - camkes-arm-vm-manifest
-      - camkes-arm-vm
       - camkes-vm-images
       - rumprun-sel4-demoapps
       - rumprun-packages
@@ -43,8 +41,6 @@ github:
       - sel4runtime
       - rumprun
       - graph-refine
-      - mcs-examples
-      - mcs-examples-manifest
       - picotcp
       - picotcp-bsd
       - isabelle
@@ -56,11 +52,8 @@ github:
       - sel4bench-manifest
       - camkes-manifest
       - camkes-vm-examples-manifest
-      - camkes-arm-vm-manifest
       - sel4webserver-manifest
-      - sel4-tutorials
       - sel4-tutorials-manifest
       - rumprun-sel4-demoapps
       - verification-manifest
-      - mcs-examples-manifest
 


### PR DESCRIPTION
- camkes-arm-vm (and -manifest) is deprecated and archived,
- mcs-examples (and -manifest) have never been in maintained status
- sel4-tutorials somehow made it into the manifest list

Closes #112
