### PR TITLE
git-conventions: Avoid style-only PRs

### DIFF
--- a/processes/git-conventions.md
+++ b/processes/git-conventions.md
@@ -37,6 +37,8 @@ Please follow the git commit [style guide](https://chris.beams.io/posts/git-comm
 
 * Please keep whitespace and style changes in their own commits, not mixed with other changes.
 * If making a trivial commit, please prefix with `trivial:`
+* Avoid making PRs that are only changing style and not making other significant changes.
+  This avoids spending reviewer and CI resources on a large number of small stylisitic improvements.
 
 ## History
 


### PR DESCRIPTION
Make explicit the convention that code should only be restyled when it
already being edited for other reasons. This is to limit change amplification
from small incremental style changes that aren't coupled to new-features
or bug-fixes.

This is a convention that has been selectively enforced historically[1], but hasn't been written down anywhere.  This PR can also serve to discuss whether the convention should continue to be enforced or not.

[1] https://github.com/seL4/util_libs/pull/84#issuecomment-841163630