### PR TITLE
Sort hardware by platform, not architecture.

### DIFF
--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -41,7 +41,7 @@ seL4 has support for select ARMv6, ARMv7 and ARMv8 Platforms.
 
 | Platform                                      | System-on-chip            | Core             | Arch  | Virtualisation | IOMMU              | Status     | Contributed by | Maintained by |
 | - | - | - | - | - | - | - | - | - |
-{%- assign sorted = site.pages | sort: 'arch' %}
+{%- assign sorted = site.pages | sort: 'platform' %}
 {% for page in sorted %}
 {%- if page.arm_hardware -%}
 | [{{ page.platform }}]({{page.url}}) | {{ page.soc}} | {{ page.cpu }} | {{ page.arch }} | {{ page.virtualization }} | {{ page.iommu}} | {{ page.Status }} | {{ page.Contrib }} | {{page.Maintained}} |


### PR DESCRIPTION
We're already filtering by architecture (arm vs risc-V); having the table sorted by platform name makes it easier to find the 
platform you're interested in.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>