### PR TITLE
Update TX2 details

### DIFF
--- a/Hardware/JetsonTX2.md
+++ b/Hardware/JetsonTX2.md
@@ -5,8 +5,8 @@ cmake_plat: tx2
 xcompiler_arg: -DAARCH64=1
 platform: TX2
 arch: ARMv8A, AArch64 only
-virtualization: "No"
-iommu: "No"
+virtualization: "Yes"
+iommu: "Yes"
 soc: NVIDIA Tegra X2
 cpu: Cortex-A57 Quad, Dual NVIDIA Denver
 Status: Unverified
@@ -22,7 +22,7 @@ The Jetson TX2 is an embedded system-on-module (SOM) developed by NVIDIA.
 <https://elinux.org/Jetson_TX2>
 
 The seL4 kernel has a limited port to the TX2 which supports the SoM
-only in 64-bit mode. SMP, SMMU, Hyp-mode, etc are not supported by the
+only in 64-bit mode. SMP is not supported by the
 current port.
 
 ## Building seL4test


### PR DESCRIPTION
The Jetson TX2 port uses the system MMU and
can run a hypervisor.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>