### PR TITLE
make code blocks use preformatted whitespace.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -223,7 +223,7 @@ div.breadcrumbs.bootstrap .breadcrumb-item + .breadcrumb-item:hover::before {
 
 h2 a,
 .api code {
-      white-space: nowrap;
+      white-space: pre;
 }
 
 .icon-resize {


### PR DESCRIPTION
Signed-off-by: matt rice <ratmice@gmail.com>

If you look at https://docs.sel4.systems/GettingStarted 
the code blocks there are being wrapped all onto one line,
this changes the css so each line of the code block will be on its own.