### PR TITLE
update link from dtd to xsd in manual gen page

### DIFF
--- a/projects/sel4/manual-api-generation.md
+++ b/projects/sel4/manual-api-generation.md
@@ -200,7 +200,7 @@ descriptions in the XML files listed above. The XML language with which
 the interfaces are described contains tags for documenting functions.
 For the purpose of validation, the XML schema defining this language is
 in:
-[libsel4/tools/sel4_idl.dtd](https://github.com/seL4/seL4/blob/master/libsel4/tools/sel4_idl.dtd).
+[libsel4/tools/sel4_idl.xsd](https://github.com/seL4/seL4/blob/master/libsel4/tools/sel4_idl.xsd).
 This is a superset of the XML tags used in doxygen comments. The doxygen
 comment tags described above have the same meaning in the interface
 description files. Additional tags are used for the description and


### PR DESCRIPTION
This is of course predicated on pr seL4/seL4#789, I had missed this link to the dtd, on my previous pass looking through the all the repos.

Signed-off-by: matt rice <ratmice@gmail.com>