### PR TITLE
Add support for the Avnet MaaXBoard (docs)

### DIFF
--- a/Hardware/MaaXBoard.md
+++ b/Hardware/MaaXBoard.md
@@ -1,0 +1,23 @@
+---
+toc: true
+arm_hardware: true
+cmake_plat: maaxboard
+xcompiler_arg: -DAARCH64=1
+platform: Avnet MaaXBoard
+arch: ARMv8A
+virtualization: "No"
+iommu: "No"
+soc: i.MX8MQ
+cpu: Cortex-A53 Quad 1.5 GHz
+Status: Unverified
+Contrib: "[Capgemini Engineering](https://capgemini-engineering.com)"
+Maintained: "[Capgemini Engineering](https://capgemini-engineering.com)"
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2022 seL4 Project a Series of LF Projects, LLC.
+---
+# Avnet MaaXBoard
+
+## Building seL4test
+
+{% include sel4test.md %}
+Also `-DAARCH32=1` is available.


### PR DESCRIPTION
This pull request is a call for feedback and comment on an initial implementation for supporting seL4 on the Avnet MaaXBoard, with the intention of the changes being merged back to the main docs repository. This pull request is dependent on three other pull requests which provide the core support for the MaaXBoard: https://github.com/seL4/seL4/pull/829, https://github.com/seL4/seL4_tools/pull/144, https://github.com/seL4/util_libs/pull/129.

This pull request adds a new row to the Supported Platforms table and provides the basic seL4test instructions.