### PR TITLE
github: do not deploy on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,9 @@ jobs:
         path: site.tar
 
   deploy:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' ||
-            github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository_owner == 'seL4' &&
+            (github.event_name == 'push' || github.event_name == 'schedule' ||
+            github.event_name == 'workflow_dispatch') }}
     needs: build
     name: 'Deploy'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes: https://github.com/seL4/docs/issues/135

Forks do not have a valid `secrets.GH_TOKEN`, thus the action will always fail.