### PR TITLE
Add host dependencies instructions for Ubuntu 20.04 and 22.04

### DIFF
--- a/Hardware/ariane.md
+++ b/Hardware/ariane.md
@@ -20,6 +20,8 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 Ariane is a 6-stage RISC-V CPU. For details, refer to
 [https://github.com/pulp-platform/ariane](https://github.com/pulp-platform/ariane)
 
+## Building the GCC toolchain
+
 {% include risc-v.md %}
 
 ## Building seL4test

--- a/Hardware/hifive.md
+++ b/Hardware/hifive.md
@@ -21,6 +21,8 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 HiFive Unleashed is a RISC-V development board by SiFive. Check
 [here](https://www.sifive.com/boards/hifive-unleashed) for details.
 
+## Building the GCC toolchain
+
 {% include risc-v.md %}
 
 ## Building seL4test

--- a/Hardware/rocketchip.md
+++ b/Hardware/rocketchip.md
@@ -21,6 +21,8 @@ for other Zynq FPGAs. Refer to
 [https://github.com/ucb-bar/fpga-zynq](https://github.com/ucb-bar/fpga-zynq) for
 details.
 
+## Building the GCC toolchain
+
 {% include risc-v.md %}
 
 ## Building seL4test

--- a/Hardware/spike.md
+++ b/Hardware/spike.md
@@ -18,6 +18,8 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 
 # Spike
 
+## Building the GCC toolchain
+
 {% include risc-v.md %}
 
 ## Getting the Simulator

--- a/_includes/risc-v.md
+++ b/_includes/risc-v.md
@@ -2,7 +2,6 @@
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 {% endcomment %}
-## Build the GCC toolchain
 
 1. It is recommended to build the toolchain from source.
 

--- a/_includes/risc-v.md
+++ b/_includes/risc-v.md
@@ -15,7 +15,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
     make linux
     ```
 
-    After it is built, add the $RISCV/bin folder to your PATH. The built
+    After it is built, add the `$RISCV/bin` folder to your PATH. The built
     toolchain works for both 32-bit and 64-bit.
 
 2. Alternatively, any pre-built toolchain with multilib enabled should work.

--- a/content_collections/_dependencies/camkes.md
+++ b/content_collections/_dependencies/camkes.md
@@ -6,13 +6,13 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 ## CAmkES Build Dependencies
 
-To build a CAmkES based project on seL4, additional dependencies need to be installed on your host machine. Projects using CAmkES (the seL4 component system) need Haskell and some extra python libraries in addition to the standard build tools. The following instructions cover the CAmkES build dependencies for Ubuntu/Debian. Please ensure you have installed the dependencies listed in sections [sel4 Build Dependencies](#sel4-build-dependencies) and [Get Google's Repo tool](#get-googles-repo-tool) prior to building a CAmkES project.
+To build a CAmkES based project on seL4, additional dependencies need to be installed on your host machine. Projects using CAmkES (the seL4 component system) need Haskell and some extra Python libraries in addition to the standard build tools. The following instructions cover the CAmkES build dependencies for Ubuntu/Debian. Please ensure you have installed the dependencies listed in sections [seL4 Build Dependencies](#sel4-build-dependencies) and [Get Google's Repo tool](#get-googles-repo-tool) prior to building a CAmkES project.
 
 ### Python Dependencies
 
-The python dependencies required by the CAmkES build toolchain can be installed via pip:
+The Python dependencies required by the CAmkES build toolchain can be installed via pip:
 
-```
+```sh
 pip3 install --user camkes-deps
 # Currently we duplicate dependencies for python2 and python3 as a python3 upgrade is in process
 pip install --user camkes-deps
@@ -36,7 +36,7 @@ sudo apt-get install haskell-stack
 
 Install the following packages on your Ubuntu machine:
 
-```
+```sh
 sudo apt-get install clang gdb
 sudo apt-get install libssl-dev libclang-dev libcunit1-dev libsqlite3-dev
 sudo apt-get install qemu-kvm

--- a/content_collections/_dependencies/camkes.md
+++ b/content_collections/_dependencies/camkes.md
@@ -32,9 +32,10 @@ sudo apt-get install haskell-stack
 ### Build Dependencies
 
 ####  Ubuntu
-> *Tested on Ubuntu 18.04 LTS*
 
-Install the following packages on your Ubuntu machine:
+These instructions are intended for Ubuntu LTS versions 18.04, 20.04, and 22.04.
+
+Install the following packages:
 
 ```sh
 sudo apt-get install clang gdb

--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -41,13 +41,17 @@ sudo apt-get install gcc-8 g++-8
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 ```
 
-To build for ARM targets you will need a cross compiler. In addition, to run seL4 projects on a simulator you will need `qemu`. Installation of these additional base dependencies include running:
+In order to run seL4 projects on a simulator you will need QEMU:
 
+```sh
+sudo apt-get install qemu-system-arm qemu-system-x86 qemu-system-misc
+```
+
+To build for ARM targets you will need a cross compiler:
 
 ```sh
 sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
 sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-sudo apt-get install qemu-system-arm qemu-system-x86 qemu-system-misc
 ```
 
 (you can install the hardware floating point versions as well if you wish)

--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -60,6 +60,10 @@ sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 ```
 
+To build for RISC-V targets you will need a cross compiler:
+
+{% include risc-v.md %}
+
 To build the seL4 manual, you will need the following LaTeX packages:
 
 ```sh

--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -21,6 +21,8 @@ As dependencies and packages may be frequently changed, deprecated or updated th
 
 > *Note that we require a minimum CMake version of 3.12.0 while Ubuntu 18.04 contains 3.10.2.  In order to correct this, a custom installation of CMake may be required which can be downloaded from: https://cmake.org/download/*
 
+**Base dependencies**
+
 The basic build package on Ubuntu is the `build-essential` package. To install run:
 
 ```sh
@@ -41,11 +43,15 @@ sudo apt-get install gcc-8 g++-8
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 ```
 
+**Simulating with QEMU**
+
 In order to run seL4 projects on a simulator you will need QEMU:
 
 ```sh
 sudo apt-get install qemu-system-arm qemu-system-x86 qemu-system-misc
 ```
+
+**Cross-compiling for ARM targets**
 
 To build for ARM targets you will need a cross compiler:
 
@@ -60,11 +66,15 @@ sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 ```
 
+**Cross-compiling for RISC-V targets**
+
 To build for RISC-V targets you will need a cross compiler:
 
 {% include risc-v.md %}
 
-To build the seL4 manual, you will need the following LaTeX packages:
+**Builidng the seL4 manual**
+
+If you would like to build the seL4 manual, you will need the following LaTeX pacakges:
 
 ```sh
 sudo apt-get install texlive texlive-latex-extra texlive-fonts-extra

--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -15,11 +15,11 @@ To establish a usable development environment it is important to install your di
 
 #### Ubuntu
 
-> *The following instructions cover the build dependencies tested on [Ubuntu 18.04](http://releases.ubuntu.com/18.04/) LTS. Note that earlier versions of Ubuntu (e.g. 16.04) may not be sufficient for building as some default development packages are
-stuck at older versions (e.g CMake 3.5.1, GCC 5.4 for 16.04).
-As dependencies and packages may be frequently changed, deprecated or updated these instructions may become out of date. If you discover any missing dependencies and packages we welcome new [contributions](https://docs.sel4.systems/DocsContributing) to the page.*
+These instructions are intended for Ubuntu LTS versions 18.04, 20.04, and 22.04.
 
-> *Note that we require a minimum CMake version of 3.12.0 while Ubuntu 18.04 contains 3.10.2.  In order to correct this, a custom installation of CMake may be required which can be downloaded from: https://cmake.org/download/*
+> *Note for Ubuntu 18.04: we require a minimum CMake version of 3.12.0 while Ubuntu 18.04 contains 3.10.2.  In order to correct this, a custom installation of CMake may be required which can be downloaded from: [https://cmake.org/download/](https://cmake.org/download/)*
+
+> As dependencies and packages may be frequently changed, deprecated or updated these instructions may become out of date. If you discover any missing dependencies and packages we welcome new [contributions](https://docs.sel4.systems/DocsContributing) to the page.
 
 **Base dependencies**
 
@@ -34,13 +34,25 @@ Additional base dependencies for building seL4 projects on Ubuntu include instal
 
 ```sh
 sudo apt-get install cmake ccache ninja-build cmake-curses-gui
-sudo apt-get install python-dev python-pip python3-dev python3-pip
 sudo apt-get install libxml2-utils ncurses-dev
 sudo apt-get install curl git doxygen device-tree-compiler
 sudo apt-get install u-boot-tools
+```
+
+For Ubuntu 18.04:
+
+```sh
+sudo apt-get install python-dev python-pip python3-dev python3-pip
 sudo apt-get install protobuf-compiler python-protobuf
 sudo apt-get install gcc-8 g++-8
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+```
+
+For Ubuntu 20.04 and 22.04:
+
+```sh
+sudo apt-get install python3-dev python3-pip python-is-python3
+sudo apt-get install protobuf-compiler python3-protobuf
 ```
 
 **Simulating with QEMU**

--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -50,7 +50,7 @@ sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 sudo apt-get install qemu-system-arm qemu-system-x86 qemu-system-misc
 ```
 
-(you can install  the hardware floating point versions as well if you wish"
+(you can install the hardware floating point versions as well if you wish)
 
 ```sh
 sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf


### PR DESCRIPTION
This PR does minor clean up and adds instructions for Ubuntu 20.04 and 22.04 on the "Host Dependencies" page.

This is a draft as:
- [x] proof/Isabelle dependencies might need updating and I have not checked yet
- [x] Need to do some more testing to make sure all seL4 projects build with the new instructions