### PR TITLE
docker: update docker env for seL4-tutorials

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,6 +6,7 @@ FROM ruby:2
 RUN apt-get update -q \
     && apt-get install -y --no-install-recommends \
         doxygen \
+        python3-dev \
         python3-bs4 \
         python3-lxml \
         python3-six \
@@ -16,7 +17,7 @@ RUN apt-get update -q \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && pip3 install setuptools \
-    && pip3 install aenum sortedcontainers pyyaml pyaml future \
+    && pip3 install aenum sortedcontainers pyyaml pyaml future camkes-deps \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Init bundle dependencies


### PR DESCRIPTION
Building the site for the seL4 tutorials now needs the full `camkes-deps` in python, which in turns needs `python3-dev`.

Native and GitHub builds are unaffected, this just updates the available background dependencies in the docker container provided for building the site.