### PR TITLE
zcu102: update cmake_plat from zynqmp to zcu102

### DIFF
--- a/Hardware/ZCU102.md
+++ b/Hardware/ZCU102.md
@@ -1,5 +1,5 @@
 ---
-cmake_plat: zynqmp
+cmake_plat: zcu102
 xcompiler_arg: -DAARCH64=1
 arm_hardware: true
 platform: Zynq ZCU102 and ZCU106 Evaluation Kits


### PR DESCRIPTION
seL4_tools was recently updated to differentiate the zynqmp platforms. This commit updates the ZCU102 guidelines to explicitly compile for the ZCU102 instead of the generic zynqmp.

Signed-off-by: Chris Guikema <chris.guikema@dornerworks.com>