### PR TITLE
fix GitHub docsite build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: Site
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -42,7 +42,7 @@ jobs:
             github.event_name == 'workflow_dispatch') }}
     needs: build
     name: 'Deploy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     name: Site
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip3 install -U camkes-deps
@@ -31,7 +31,7 @@ jobs:
     - run: sudo gem install bundler
     - run: make build JEKYLL_ENV=production
     - run: tar -cvf site.tar _site/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: site
         path: site.tar
@@ -44,13 +44,13 @@ jobs:
     name: 'Deploy'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: gh-pages
         token: ${{ secrets.GH_TOKEN }}
     # for removing files, we need to start fresh; this does not remove dot-files
     - run: rm -rf *
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: site
     - run: tar -xvf site.tar


### PR DESCRIPTION
- pin runner OS version to Ubuntu 20.04, which contains the right versions of ruby + bundler until we have updated the main build
- bump action versions to Node 16 actions