### PR TITLE
roles: clarify GitHub access of TSC members

### DIFF
--- a/processes/roles.md
+++ b/processes/roles.md
@@ -78,7 +78,8 @@ You can nominate someone for a role by emailing the chair of the TSC.
     of the project, sets processes, guidelines, etc. Meetings of the TSC
     are public and will be announced on the seL4 developer mailing list.
 
-   See [the TSC page][2] for current members.
+   See [the TSC page][2] for current members. TSC members have at least
+   Committer access to the seL4 GitHub repositories.
 
 [1]: https://sel4.systems/Foundation/About
 [2]: https://sel4.systems/Foundation/TSC/


### PR DESCRIPTION
TSC members have Committer and/or Admin access, depending on how involved they are with the administration of the repositories.