### PR TITLE
Add Odroid-C4 as supported platform

### DIFF
--- a/Hardware/OdroidC4.md
+++ b/Hardware/OdroidC4.md
@@ -1,0 +1,40 @@
+---
+toc: true
+arm_hardware: true
+cmake_plat: odroidc4
+xcompiler_arg: -DAARCH64=1
+platform: Odroid-C4
+arch: ARMv8A, AArch64 only
+virtualization: "Yes"
+iommu: "No"
+soc: Amlogic S905X3
+cpu: Cortex-A55
+Status: Unverified
+Contrib: Data61
+Maintained: seL4 Foundation
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
+---
+
+# Odroid-C4
+
+The Odroid-C4 is a single board computer based on the Amlogic S905X3
+System-on-Chip.
+
+<https://wiki.odroid.com/odroid-c4/odroid-c4>
+
+Note that only 64-bit mode is supported.
+
+## Building seL4test
+
+{% include sel4test.md %}
+
+## Booting via TFTP
+
+Make sure you've set up a TFTP server to serve the seL4 image.
+
+```
+dhcp
+tftp 0x20000000 <YOUR_TFTP_SERVER_IP_ADDRESS>:sel4test-driver-image-arm-odroidc4
+go 0x20000000
+```


### PR DESCRIPTION
This PR simply adds a dedicated page for the Odroid-C4, the board has actually been supported since https://github.com/seL4/seL4/pull/447.

The main difference between this page and the Odroid-C2 page is that we did not encounter any kernel corruption issues when using the default U-Boot that came on the board and seL4test.