### PR TITLE
drop support for Cogent

### DIFF
--- a/_data/projects/camkes.yml
+++ b/_data/projects/camkes.yml
@@ -607,12 +607,6 @@ components:
     maintainer: "maintainer wanted"
     status: "Supported"
     component_type: camkes-application
-  - name: uart_cogent
-    display_name: uart_cogent
-    description: "A CAmkES application which demonstrates a prototype UART driver for the sabrelite platform that is written in Cogent."
-    maintainer: "maintainer wanted"
-    status: "Supported"
-    component_type: camkes-application
   - name: vgatest
     display_name: vgatest
     description: "A CAmkES application which demonstrates a minimal implementation for a text mode VGA terminal."


### PR DESCRIPTION
The Cogent project is no longer actively developed on top of seL4.