### PR TITLE
hardware: update booting command for RPi4

### DIFF
--- a/Hardware/Rpi4.md
+++ b/Hardware/Rpi4.md
@@ -93,5 +93,5 @@ so far to make sure you didn't forget something along the way. If you
 see your file listed, then do something like:
 ```
 fatload mmc 0 0x10000000 sel4test-driver-image-arm-bcm2711
-bootefi 0x10000000
+go 0x10000000
 ```


### PR DESCRIPTION
Depends on https://github.com/seL4/seL4_tools/pull/167

I have another patch that revamps the RPi documentation but it's not done yet hopefully I'll get back to it soon but this patch at least means that the booting command is correct.