### PR TITLE
Remove dependency instructions for Ubuntu 18.04

### DIFF
--- a/content_collections/_dependencies/camkes.md
+++ b/content_collections/_dependencies/camkes.md
@@ -31,7 +31,7 @@ sudo apt-get install haskell-stack
 
 ####  Ubuntu
 
-These instructions are intended for Ubuntu LTS versions 18.04, 20.04, and 22.04.
+These instructions are intended for Ubuntu LTS versions 20.04 and 22.04.
 
 Install the following packages:
 

--- a/content_collections/_dependencies/sel4.md
+++ b/content_collections/_dependencies/sel4.md
@@ -15,9 +15,7 @@ To establish a usable development environment it is important to install your di
 
 #### Ubuntu
 
-These instructions are intended for Ubuntu LTS versions 18.04, 20.04, and 22.04.
-
-> *Note for Ubuntu 18.04: we require a minimum CMake version of 3.12.0 while Ubuntu 18.04 contains 3.10.2.  In order to correct this, a custom installation of CMake may be required which can be downloaded from: [https://cmake.org/download/](https://cmake.org/download/)*
+These instructions are intended for Ubuntu LTS versions 20.04 and 22.04.
 
 > As dependencies and packages may be frequently changed, deprecated or updated these instructions may become out of date. If you discover any missing dependencies and packages we welcome new [contributions](https://docs.sel4.systems/DocsContributing) to the page.
 
@@ -37,20 +35,6 @@ sudo apt-get install cmake ccache ninja-build cmake-curses-gui
 sudo apt-get install libxml2-utils ncurses-dev
 sudo apt-get install curl git doxygen device-tree-compiler
 sudo apt-get install u-boot-tools
-```
-
-For Ubuntu 18.04:
-
-```sh
-sudo apt-get install python3-dev python3-pip
-sudo apt-get install protobuf-compiler python-protobuf
-sudo apt-get install gcc-8 g++-8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
-```
-
-For Ubuntu 20.04 and 22.04:
-
-```sh
 sudo apt-get install python3-dev python3-pip python-is-python3
 sudo apt-get install protobuf-compiler python3-protobuf
 ```


### PR DESCRIPTION
The Ubuntu 18.04 OS has been deprecated since April 2023.