### PR TITLE
github: fetch history for page modification dates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        fetch-depth: 0
         submodules: true
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The site figures out page modification dates by git commit, but if we only fetch the latest revision, all dates will just have the last commit.

Fixes #196