### PR TITLE
github: fix bundler version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: 3.9
     - run: pip3 install -U camkes-deps
     - run: sudo apt-get install doxygen
-    - run: sudo gem install bundler
+    - run: sudo gem install bundler -v 2.4.22
     - run: make build JEKYLL_ENV=production
     - run: tar -cvf site.tar _site/
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes github website build.

The latest version of bundler requires ruby 3.0, but we're still on 2.7 for now.