### PR TITLE
hardware: make title consistent in page/menus

### DIFF
--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
-# Supported hardware platforms
+# Supported platforms
 
 ### Summary
 

--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
-# Supported Platforms
+# Supported hardware platforms
 
 ## Verification status
 

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -13,7 +13,7 @@ toc:
         url: /projects/sel4/frequently-asked-questions.html
       - page: Set up your machine
         url: /projects/buildsystem/host-dependencies.html
-      - page: Supported hardware
+      - page: Supported hardware platforms
         url: /Hardware/
       - page: Available components
         url: /projects/available-user-components.html

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -13,7 +13,7 @@ toc:
         url: /projects/sel4/frequently-asked-questions.html
       - page: Set up your machine
         url: /projects/buildsystem/host-dependencies.html
-      - page: Supported hardware platforms
+      - page: Supported platforms
         url: /Hardware/
       - page: Available components
         url: /projects/available-user-components.html

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ This documentation site is for cooperatively developing and sharing documentatio
 	<li><a href="/projects/roadmap.html">Roadmap</a></li>
 	<li><a href="/projects/buildsystem/host-dependencies.html">Build dependencies</a></li>
 	<li><a href="/GettingStarted#running-sel4">Building and Running seL4</a></li>
-	<li><a href="/Hardware">Hardware and Target platforms</a></li>
+	<li><a href="/Hardware">Supported hardware platforms</a></li>
 	<li><a href="/projects/sel4/verified-configurations.html">Verification targets and claims</a></li>
 	</ul>
   </div>

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ This documentation site is for cooperatively developing and sharing documentatio
 	<li><a href="/projects/roadmap.html">Roadmap</a></li>
 	<li><a href="/projects/buildsystem/host-dependencies.html">Build dependencies</a></li>
 	<li><a href="/GettingStarted#running-sel4">Building and Running seL4</a></li>
-	<li><a href="/Hardware">Supported hardware platforms</a></li>
+	<li><a href="/Hardware">Supported platforms</a></li>
 	<li><a href="/projects/sel4/verified-configurations.html">Verification targets and claims</a></li>
 	</ul>
   </div>


### PR DESCRIPTION
Used the term "Supported hardware platforms" (after discussion with Gerwin) for: the Hardware page title, the side menu and the landing page (table of content).