### PR TITLE
DOCSITE: Reorganise tutorials and add inline solutions

### DIFF
--- a/Hardware/Beaglebone.md
+++ b/Hardware/Beaglebone.md
@@ -27,7 +27,7 @@ a community-supported port.
 
 ### Requirements
 We suggest using the `arm-linux-gnueabi-` cross-compilers. Use
-[the instructions on getting a toolchain](/GettingStarted#getting-cross-compilers).
+[the instructions on getting a toolchain](/Resources#getting-cross-compilers).
 
 ### Building
 

--- a/Hardware/HiKey/index.md
+++ b/Hardware/HiKey/index.md
@@ -23,7 +23,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 - One HiKey Board. See
         [Hikey 96Board](http://www.96boards.org/products/ce/hikey/)
 - Fully working development environment. See
-        [Getting started](/GettingStarted)
+        [Resources](/Resources)
 
 ### Getting Started
  The Hikey board is based around the
@@ -87,12 +87,12 @@ gedit LinaroPkg/platforms.config
 BUILDFLAGS=-DSERIAL_BASE=0xF8015000
 ATF_BUILDFLAGS=CONSOLE_BASE=PL011_UART0_BASE CRASH_CONSOLE_BASE=PL011_UART0_BASE
 ```
-## 5. Patching the UEFI for the Hikey 
+## 5. Patching the UEFI for the Hikey
 Obtain the patch from [edk2.patch](edk2.patch) and follow the below steps.
 
 ```bash
-cd linaro-edk2 
-patch -p1 < ~/Downloads/edk2.patch 
+cd linaro-edk2
+patch -p1 < ~/Downloads/edk2.patch
 # Then return to the main directory hikey-flash
 ```
 
@@ -206,8 +206,8 @@ sudo minicom -s
   7.  Three terminals are then required for the following commands
 
 ```bash
-# In the first terminal 
-ls 
+# In the first terminal
+ls
 # Note the next ttyUSBY that is observed, in addition to the current ttyUSBX
 
 # In the third terminal

--- a/Hardware/VMware/index.md
+++ b/Hardware/VMware/index.md
@@ -14,7 +14,7 @@ and for a Linux host machine. May work on Mac host machine, won't work
 for Windows host (although general idea should be similar).
 
 This guide assumes that your project is all set up and configured to
-build for x86. Read [Getting started](/GettingStarted) otherwise.
+build for x86. Read [Resources](/Resources) otherwise.
 
 ## Setting up a VM
 
@@ -55,7 +55,7 @@ There are three options for the serial port
 set up). You'll want to apt-get install socat and then run something
 like:
 ```bash
-#!/bin/bash 
+#!/bin/bash
 while true; do
     socat -d -d UNIX-CONNECT:/tmp/vsock,forever PTY:link=/dev/tty99
 done

--- a/Hardware/jetsontk1.md
+++ b/Hardware/jetsontk1.md
@@ -20,10 +20,10 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 
 The [Jetson TK1](http://www.nvidia.com/object/jetson-tk1-embedded-dev-kit.html) is a affordable embedded system developed by NVIDIA. It runs
 seL4. We will explain how to run seL4 on the Tegra.
- 
+
 ### Pre-Requisites
 * One Tegra Board. See [Jetson TK1](http://www.nvidia.com/object/jetson-tk1-embedded-dev-kit.html)
-* The development environment fully working.  See [Getting started](/GettingStarted)
+* The development environment fully working.  See [Resources](/Resources)
 
 ## Getting Started
  To get started, check out the
@@ -94,7 +94,7 @@ to boot in nonsecure (HYP)
 mode. This also enables kvm if you boot Linux.
 
 To go back to secure mode booting do
-``` 
+```
 setenv bootm_boot_mode sec
 saveenv
 ```

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,10 @@ _repos/tutes:
 _repos/tutes/%.md: _repos/sel4proj/sel4-tutorials/tutorials/% _repos/tutes
 	PYTHONPATH=_repos/sel4/capdl/python-capdl-tool _repos/sel4proj/sel4-tutorials/template.py --docsite --out-dir _repos/tutes --tut-file $</$(@F)
 
-TUTORIALS:= $(filter-out index.md,$(notdir $(wildcard Tutorials/*.md)))
+# Make tutorials
+# Filter out index.md; get-the-tutorials.md; how-to.md pathways.md; setting-up.md
+# which are docsite pages, and not in the tutorials repo
+TUTORIALS:= $(filter-out index.md get-the-tutorials.md how-to.md pathways.md setting-up.md,$(notdir $(wildcard Tutorials/*.md)))
 tutorials: ${TUTORIALS:%=_repos/tutes/%}
 
 _generate_api_pages: $(REPOSITORIES)

--- a/Resources.md
+++ b/Resources.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 
-# Getting Started
+# Resources
 
-This page is a quick start for working with seL4 and its ecosystem.
+This page provides an overview of working with seL4 and its ecosystem.
 
 ## Background and terminology
 
@@ -168,7 +168,12 @@ You can find a long list of seL4 publications here:
 - [seL4 is free: What does this mean for you? (2015)](https://www.youtube.com/watch?v=lRndE7rSXiI).
 - [From L3 to seL4: What have we learned in 20 years of L4 microkernels? (2014)](https://www.youtube.com/watch?v=RdoaFc5-1Rk).
 
-## Get Help
+## Contact
+
+### Forums
+
+- [Discourse forum](https://sel4.discourse.group/)
+- [Mattermost channel](https://mattermost.trustworthy.systems/sel4-external/)
 
 ### Mailing lists
 

--- a/SuggestedProjects.md
+++ b/SuggestedProjects.md
@@ -6,7 +6,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 # Suggested Projects
 
 
-After trying the existing projects (especially those listed on [Getting started](GettingStarted))
+After trying the existing projects (e.g. the [Tutorials](Tutorials))
 a good way to learn the intricacies of programming on
 top of seL4 is to do the exercises in the
 [UNSW Advanced

--- a/Tutorials/camkes-vm-crossvm.md
+++ b/Tutorials/camkes-vm-crossvm.md
@@ -1,11 +1,11 @@
 ---
 toc: true
-title: Camkes Cross-VM communication
+title: Camkes cross-VM connectors
 tutorial: camkes-vm-crossvm
+description: walkthrough of adding communication between Linux guests in separate VMs
 tutorial-order: vm-2
-description: walkthrough of adding communication between Linux guests in separate VMs.
+layout: tutorial
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/camkes-vm-linux.md
+++ b/Tutorials/camkes-vm-linux.md
@@ -3,9 +3,9 @@ toc: true
 title: Camkes VM Linux
 tutorial: camkes-vm-linux
 tutorial-order: vm-1
-description: using Linux as a guest in the Camkes VM.
+layout: tutorial
+description: using Linux as a guest in the Camkes VM
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/capabilities.md
+++ b/Tutorials/capabilities.md
@@ -2,9 +2,10 @@
 toc: true
 title: Capabilities
 tutorial: capabilities
-tutorial-order: mechanisms-1
-description: an introduction to capabilities in the seL4 kernel API.
+layout: tutorial
+description: an introduction to capabilities in the seL4 kernel API
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
+
 {% include tutorial.md %}

--- a/Tutorials/fault-handlers.md
+++ b/Tutorials/fault-handlers.md
@@ -2,8 +2,8 @@
 toc: true
 title: Faults
 tutorial: fault-handlers
-tutorial-order: mechanisms-8
-description: fault (e.g virtual memory fault) handling and fault endpoints.
+layout: tutorial
+description: fault (e.g virtual memory fault) handling and fault endpoints
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---

--- a/Tutorials/get-the-tutorials.md
+++ b/Tutorials/get-the-tutorials.md
@@ -1,0 +1,33 @@
+---
+toc: true
+title: Getting the tutorials
+layout: tutorial
+description: steps and code for getting tutorials
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2024 seL4 Project a Series of LF Projects, LLC.
+---
+
+# Getting the tutorials
+## Python Dependencies
+The CAmkES python dependencies are required to build the [tutorials](ReworkedTutorials). To install you can run:
+```
+pip3 install --user camkes-deps
+```
+*Hint:* This step only needs to be done once, i.e. before doing your first tutorial.
+
+## Get the code
+All code for the tutorials is described in the <a href="https://github.com/seL4/sel4-tutorials-manifest">sel4-tutorials-manifest</a>. Get the code with:
+```
+mkdir sel4-tutorials-manifest
+cd sel4-tutorials-manifest
+repo init -u https://github.com/seL4/sel4-tutorials-manifest
+repo sync
+```
+
+`repo sync` may take a few moments to run
+
+*Hint:* The **Get the code** step only needs to be done once, i.e. before doing your first tutorial.
+
+<p>
+    Next: <a href="hello-world">Hello world</a>
+</p>

--- a/Tutorials/hello-camkes-0.md
+++ b/Tutorials/hello-camkes-0.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Camkes
+title: Hello CAmkES
 tutorial: hello-camkes-0
-tutorial-order: camkes-0
-description: an introduction to Camkes concepts.
+layout: tutorial
+description: an introduction to CAmkES concepts
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/hello-camkes-1.md
+++ b/Tutorials/hello-camkes-1.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Camkes 1
+title: Introduction to CAmkES
 tutorial: hello-camkes-1
-tutorial-order: camkes-1
-description: an introduction to Camkes concepts.
+layout: tutorial
+description: an introduction to CAmkES concepts
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/hello-camkes-2.md
+++ b/Tutorials/hello-camkes-2.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Camkes 2
+title: Events in CAmkES
 tutorial: hello-camkes-2
-tutorial-order: camkes-2
-description: an introduction to Camkes concepts.
+layout: tutorial
+description: an introduction to CAmkES concepts
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/hello-camkes-timer.md
+++ b/Tutorials/hello-camkes-timer.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Camkes 3
+title: CAmkES timer tutorial
 tutorial: hello-camkes-timer
-tutorial-order: camkes-3
-description: introduce Camkes hardware components.
+layout: tutorial
+description: introduce CAmkES hardware components
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/hello-world.md
+++ b/Tutorials/hello-world.md
@@ -2,9 +2,10 @@
 toc: true
 title: Hello, World!
 tutorial: hello-world
-tutorial-order: 0-hello
-description: an introduction to seL4 projects and tutorials.
+layout: tutorial
+description: an introduction to seL4 projects and tutorials
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
+
 {% include tutorial.md %}

--- a/Tutorials/how-to.md
+++ b/Tutorials/how-to.md
@@ -1,0 +1,201 @@
+---
+toc: true
+layout: tutorial
+description: how-to guide with links to tutorial solutions
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2024 seL4 Project a Series of LF Projects, LLC.
+---
+# <em>How to:</em> A quick solutions guide
+This guide provides links to tutorial solutions as quick references for seL4 calls and methods.
+
+[//]: # (<html><a href="no-javascript.html" title="Get some foo!">Show me some foo</a></html>)
+
+## The seL4 kernel
+
+{% assign url = "capabilities?tut_expand" %}
+### [Capabilities]({{ url }})
+
+ - [Calculate the size of a CSpace]({{ url }}#how-big-is-your-cspace)
+ - [Copy a capability between CSlots]({{ url }}#copy-a-capability-between-cslots)
+ - [Delete a capability]({{ url }}#how-do-you-delete-capabilities)
+ - [Suspend a thread]({{ url }}#suspend-a-thread)
+
+{% assign url = "untyped?tut_expand" %}
+### [Untyped]({{ url }})
+
+ - [Create an untyped capability]({{ url }}#create-an-untyped-capability)
+ - [Create a TCB object]({{ url }}#create-a-tcb-object)
+ - [Create an endpoint object]({{ url }}#create-an-endpoint-object)
+ - [Create a notification object]({{ url }}#create-a-notification-object)
+ - [Delete an object]({{ url }}#delete-the-objects)
+
+{% assign url = "mapping?tut_expand" %}
+### [Mapping]({{ url }})
+- [Map a page directory]({{ url }}#map-a-page-directory)
+- [Map a page table]({{ url }}#map-a-page-table)
+- [Remap a page]({{ url }}#remap-a-page)
+- [Unmap a page]({{ url }}#unmapping-pages)
+
+{% assign url = "threads?tut_expand" %}
+### [Threads]({{ url }})
+- [Configure a TCB]({{ url }}#configure-a-tcb)
+- [Change the priority of a thread]({{ url }}#change-priority-via-sel4_tcb_setpriority)
+- [Set initial register state]({{ url }}#set-initial-register-state)
+- [Start the thread]({{ url }}#start-the-thread)
+- [Set the arguments of a thread]({{ url }}#passing-arguments)
+- [Resolve a fault]({{ url }}#resolving-a-fault)
+
+{% assign url = "ipc?tut_expand" %}
+### [IPC]({{ url }})
+ - [Use capability transfer to send the badged capability]({{ url }}#use-capability-transfer-to-send-the-badged-capability)
+ - [Get a message]({{ url }}#get-a-message)
+ - [Reply and wait]({{ url }}#reply-and-wait)
+ - [Save a reply and store reply capabilities]({{ url }}#save-a-reply-and-store-reply-capabilities)
+
+{% assign url = "notifications?tut_expand" %}
+### [Notifications]({{ url }})
+ - [Set up shared memory]({{ url }}#set-up-shared-memory)
+ - [Signalling]({{ url }}#signal-the-producers-to-go)
+ - [Differentiate signals]({{ url }}#differentiate-signals)
+
+{% assign url = "interrupts?tut_expand" %}
+### [Interrupts]({{ url }})
+ - [Invoke IRQ control]({{ url }}#invoke-irq-control)
+ - [Set NTFN]({{ url }}#set-ntfn)
+ - [Acknowledge an interrupt]({{ url }}#acknowledge-an-interrupt)
+
+{% assign url = "fault-handlers?tut_expand" %}
+### [Fault handling]({{ url }})
+ - [Set up an endpoint for thread fault IPC messages]({{ url }}#setting-up-the-endpoint-to-be-used-for-thread-fault-ipc-messages)
+ - [Receive an IPC message from the kernel]({{ url }}#receiving-the-ipc-message-from-the-kernel)
+ - [Get information about a thread fault]({{ url }}#finding-out-information-about-the-generated-thread-fault)
+ - [Handle a thread fault]({{ url }}#handling-a-thread-fault)
+ - [Resume a faulting thread]({{ url }}#resuming-a-faulting-thread)
+
+{% assign url = "mcs?tut_expand" %}
+## [MCS Extensions]({{ url }})
+ - [Set up a periodic thread]({{ url }}#periodic-threads)
+ - [Unbind a scheduling context]({{ url }}#unbinding-scheduling-contexts)
+ - [Experiment with sporadic tasks]({{ url }}#sporadic-threads)
+ - [Use passive servers]({{ url }}#passive-servers)
+ - [Configure fault endpoints]({{ url }}#configuring-a-fault-endpoint-on-the-mcs-kernel)
+
+{% assign url = "libraries-1?tut_expand" %}
+## [Dynamic libraries]({{ url }})
+
+### [Initialisation  & threading]({{ url }})
+  - [Obtain BootInfo]({{ url }}#obtain-bootinfo)
+  - [Initialise simple]({{ url }}#initialise-simple)
+  - [Use simple to print BootInfo]({{ url }}#use-simple-to-print-bootinfo)
+  - [Initialise an allocator]({{ url }}#initialise-an-allocator)
+  - [Obtain a generic allocation interface (vka)]({{ url }}#obtain-a-generic-allocation-interface-vka)
+  - [Find the CSpace root cap]({{ url }}#find-the-cspace-root-cap)
+  - [Find the VSpace root cap]({{ url }}#find-the-vspace-root-cap)
+  - [Allocate a TCB Object]({{ url }}#allocate-a-tcb-object)
+  - [Configure the new TCB]({{ url }}#configure-the-new-tcb)
+  - [Name the new TCB]({{ url }}#name-the-new-tcb)
+  - [Set the instruction pointer]({{ url }}#set-the-instruction-pointer)
+  - [Set the stack pointer]({{ url }}#set-the-stack-pointer)
+  - [Write the registers]({{ url }}#write-the-registers)
+  - [Start the new thread]({{ url }}#start-the-new-thread)
+  - [Print]({{ url }}#print-something)
+
+{% assign url = "libraries-2?tut_expand" %}
+### [IPC]({{ url }})
+  - [Allocate an IPC buffer]({{ url }}#allocate-an-ipc-buffer)
+  - [Allocate a page table]({{ url }}#allocate-a-page-table)
+  - [Map a page table]({{ url }}#map-a-page-table)
+  - [Map a page]({{ url }}#map-a-page)
+  - [Allocate an endpoint]({{ url }}#allocate-an-endpoint)
+  - [Badge an endpoint]({{ url }}#badge-an-endpoint)
+  - [Set a message register]({{ url }}#message-registers)
+  - [Send and wait for a reply]({{ url }}#ipc)
+  - [Receive a reply]({{ url }}#receive-a-reply)
+  - [Receive an IPC]({{ url }}#receive-an-ipc)
+  - [Validate a message]({{ url }}#validate-the-message)
+  - [Write the message registers]({{ url }}#write-the-message-registers)
+  - [Reply to a message]({{ url }}#reply-to-a-message)
+
+{% assign url = "libraries-3?tut_expand" %}
+### [Processes & Elf loading]({{ url }})
+  - [Create a VSpace object]({{ url }}#virtual-memory-management)
+  - [Configure a process]({{ url }}#configure-a-process)
+  - [Get a CSpace path]({{ url }}#get-a-cspacepath)
+  - [Badge a capability]({{ url }}#badge-a-capability)
+  - [Spawn a process]({{ url }}#spawn-a-process)
+  - [Receive a message]({{ url }}#receive-a-message)
+  - [Send a reply]({{ url }}#send-a-reply)
+  - [Initiate communications by using seL4_Call]({{ url }}#client-call)
+
+{% assign url = "libraries-4?tut_expand" %}
+### [Timer]({{ url }})
+  - [Allocate a notification object]({{ url }}#allocate-a-notification-object)
+  - [Initialise a timer]({{ url }}#initialise-the-timer)
+  - [Use a timer]({{ url }}#use-the-timer)
+  - [Handle an interrupt]({{ url }}#handle-the-interrupt)
+  - [Destroy a timer]({{ url }}#destroy-the-timer)
+
+## [CAmkES](hello-camkes-0?tut_expand)
+
+{% assign url = "hello-camkes-1?tut_expand" %}
+### [A basic CAmkES application]({{ url }})
+  - [Define an instance in the composition section of the ADL]({{ url }}#define-an-instance-in-the-composition-section-of-the-adl)
+  - [Add a connection]({{ url }}#add-a-connection)
+  - [Define an interface]({{ url }}#define-an-interface)
+  - [Implement an RPC function]({{ url }}#implement-a-rpc-function)
+  - [Invoke a RPC function]({{ url }}#invoke-a-rpc-function)
+
+{% assign url = "hello-camkes-2?tut_expand" %}
+### [Events in CAmkES]({{ url }})
+  - [Specify an events interface]({{ url }}#specify-an-events-interface)
+  - [Add connections]({{ url }}#add-connections)
+  - [Wait for data to become available]({{ url }}#wait-for-data-to-become-available)
+  - [Signal that data is available]({{ url }}#signal-that-data-is-available)
+  - [Register a callback handler]({{ url }}#register-a-callback-handler)
+  - [Specify dataport interfaces]({{ url }}#specify-dataport-interfaces)
+  - [Specify dataport connections]({{ url }}#specify-dataport-connections)
+  - [Copy strings to an untyped dataport]({{ url }}#copy-strings-to-an-untyped-dataport)
+  - [Read the reply data from a typed dataport]({{ url }}#read-the-reply-data-from-a-typed-dataport)
+  - [Send data using dataports]({{ url }}#send-data-using-dataports)
+  - [Read data from an untyped dataport]({{ url }}#read-data-from-an-untyped-dataport)
+  - [Put data into a typed dataport]({{ url }}#put-data-into-a-typed-dataport)
+  - [Read data from a typed dataport]({{ url }}#read-data-from-a-typed-dataport)
+  - [Set component priorities]({{ url }}#set-component-priorities)
+  - [Restrict access to dataports]({{ url }}#restrict-access-to-dataports)
+  - [Test the read and write permissions on the dataport]({{ url }}#test-the-read-and-write-permissions-on-the-dataport)
+
+{% assign url = "hello-camkes-timer?tut_expand" %}
+### [CAmkES Timer]({{ url }})
+  - [Instantiate a Timer and Timerbase]({{ url }}#instantiate-a-timer-and-timerbase)
+  - [Connect a timer driver component]({{ url }}#connect-a-timer-driver-component)
+  - [Configure a timer hardware component instance]({{ url }}#configure-a-timer-hardware-component-instance)
+  - [Call into a supplied driver to handle the interrupt]({{ url }}#call-into-a-supplied-driver-to-handle-the-interrupt)
+  - [Stop a timer]({{ url }}#stop-a-timer)
+  - [Acknowledge an interrupt]({{ url }}#acknowledge-an-interrupt)
+  - [Get a timer handler]({{ url }}#get-a-timer-handler)
+  - [Start a timer]({{ url }}#start-a-timer)
+  - [Implement an RPC interface]({{ url }}#implement-a-rpc-interface)
+  - [Set a timer interrupt]({{ url }}#set-a-timer-interrupt)
+  - [Instantiate a TimerDTB component]({{ url }}#instantiate-a-timerdtb-component)
+  - [Connect interfaces using the seL4DTBHardware connector]({{ url }}#connect-interfaces-using-the-sel4dtbhardware-connector)
+  - [Configure the TimerDTB component]({{ url }}#configure-the-timerdtb-component)
+  - [Handle the interrupt]({{ url }}#handle-the-interrupt)
+  - [Stop the timer]({{ url }}#stop-the-timer)
+
+{% assign url = "camkes-vm-linux?tut_expand" %}
+### [CAmkES VM Linux]({{ url }})
+  - [Add a program]({{ url }}#adding-a-program)
+  - [Add a kernel module]({{ url }}#adding-a-kernel-module)
+  - [Create a hypercall]({{ url }}#creating-a-hypercall)
+
+{% assign url = "camkes-vm-crossvm?tut_expand" %}
+### [CAmkeES Cross VM Connectors]({{ url }})
+  - [Add modules to the guest]({{ url }}#add-modules-to-the-guest)
+  - [Define interfaces in the VMM]({{ url }}#define-interfaces-in-the-vmm)
+  - [Define the component interface]({{ url }}#define-the-component-interface)
+  - [Instantiate the print server]({{ url }}#instantiate-the-print-server)
+  - [Implement the print server]({{ url }}#implement-the-print-server)
+  - [Implement the VMM side of the connection]({{ url }}#implement-the-vmm-side-of-the-connection)
+  - [Update the build system]({{ url }}#update-the-build-system)
+  - [Add interfaces to the Guest]({{ url }}#add-interfaces-to-the-guest)
+  - [Create a process]({{ url }}#create-a-process)

--- a/Tutorials/index.md
+++ b/Tutorials/index.md
@@ -1,27 +1,31 @@
 ---
 toc: true
-redirect_from:
-  - /projects/sel4-tutorials.html
-  - /projects/sel4-tutorials/
-layout: project
-project: sel4-tutorials
+title: Tutorials
+layout: tutorial
+description: overview of seL4 and related tutorials
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
+# Overview
 
-# Tutorials
+We have developed a series of tutorials to introduce seL4 and developing systems on seL4.
 
-{% assign tutorials = site.pages | where_exp: 'page', 'page.tutorial' | sort: 'tutorial-order' %}
+## List of tutorials
+The tutorials are split into a number of broad categories, and have been designed around developer needs.
 
-We have developed a series of tutorials to introduce seL4 and
-developing systems on seL4.
+- The [seL4 tutorials](setting-up.md) are for people keen to learn about the base mechanisms provided by the seL4 kernel. The kernel API is explained with short exercises that show basic examples.
 
-## How to use the tutorials
+- [MCS](mcs) introduces seL4 Mixed-Criticality System extensions, which are detailed in this [paper](https://trustworthy.systems/publications/full_text/Lyons_MAH_18.pdf) and [PhD](https://github.com/pingerino/phd/blob/master/phd.pdf).
 
-Depending on your goals and what you want to do with seL4, we suggest
-different paths to follow through the tutorial material.  Choose the
-most relevant category below and follow the tutorials in the suggested
-order.
+- [Libraries](libraries-1) provides walkthroughs and exercises for using the libraries provided in `seL4_libs`, which were developed for rapidly prototyping systems on seL4.
+
+- [CAmkES](hello-camkes-0) generates the glue code for interacting with seL4 and is designed for building high-assurance, static systems. These tutorials demonstrate how to configure static systems through components.
+
+- [Microkit](https://trustworthy.systems/projects/microkit/tutorial/) enables system designers to create static software systems based on the seL4 microkernel. We recommend this as a potential introduction to seL4, bearing in mind that the Microkit hides many of the seL4 mechanisms - it is designed that way, to make building on top of seL4 easier.
+
+- [Rust](https://github.com/seL4/rust-sel4) allows people to write safer user-level code on top of seL4 without needing full formal verification, with a language that is receiving increasing interest and that aligns extremely well with security and safety critical embedded systems programming.
+
+**Recommended reading**
 
 Note that all of these tutorials require C programming
 experience and some understanding of operating systems and computer
@@ -32,222 +36,17 @@ architecture.  Suggested resources for these include:
 - Operating Systems:
 	- [Modern Operating Systems (book)](https://www.amazon.com/Modern-Operating-Systems-Andrew-Tanenbaum/dp/013359162X)
 	- [COMP3231 at UNSW](http://www.cse.unsw.edu.au/~cs3231)
-- Computer Architecture
-	- [Computer Architecture (wikipedia)](https://en.wikipedia.org/wiki/Computer_architecture)
-	- [Instruction Set Architecture (wikipedia)](https://en.wikipedia.org/wiki/Instruction_set_architecture)
 
-### Evaluation
+## Resources
+Additional resources to assist with learning:
+- The [seL4 manual](https://sel4.systems/Info/Docs/seL4-manual-latest.pdf)
+- [API references](../../projects/sel4/api-doc)
+- The [How to](how-to) page provides links to tutorial solutions as quick references for seL4 calls and methods.
+- The [seL4 white paper](https://sel4.systems/About/seL4-whitepaper.pdf)
+- [FAQs](../../projects/sel4/frequently-asked-questions)
+- [Debugging guide](../../projects/sel4-tutorials/debugging-guide)
+- [Contact](../../Resources#contact)
 
-Goal:
-
-- You want to understand what seL4 is and what benefits it gives.
-- You want to understand how seL4 can be used to develop trustworthy systems.
-- You want to get your hands a little dirty and see, compile, and run some code.
-
-Follow these tutorials:
-
-1. [seL4 overview](https://sel4.systems/About/seL4-whitepaper.pdf)
-2. [Introduction tutorial](#introduction-tutorial)
-
-### System Building
-
-Goal:
-
-- You want to build systems based on seL4.
-- You want to know what tools are available to do so and how to use those tools.
-- You want experience with how to use seL4 and the tools to build trustworthy systems.
-
-Follow these tutorials:
-
-1. [seL4 overview](https://sel4.systems/About/seL4-whitepaper.pdf)
-2. [Introduction tutorial](#introduction-tutorial)
-3. [CAmkES tutorials](#camkes-tutorials)
-4. [Virtualisation tutorials](#virtual-machines)
-5. [MCS tutorial](#mcs-extensions)
-
-### Platform Development
-
-Goal:
-
-- You want to contribute to development of the seL4 (user-level) platform.
-- You want to develop operating system services and device drivers.
-- You want to develop seL4-based frameworks and operating systems.
-
-Follow these tutorials:
-
-1. [seL4 overview](https://sel4.systems/About/seL4-whitepaper.pdf)
-2. [Introduction tutorial](#introduction-tutorial)
-3. [seL4 mechanisms tutorial](#seL4-mechanisms-tutorials)
-4. [Rapid prototyping tutorials](#rapid-prototyping-tutorials)
-5. [CAmkES tutorials](#camkes-tutorials)
-6. [Virtualisation tutorial](#virtual-machines)
-7. [MCS tutorial](#mcs-extensions)
-<!-- 8. Device driver tutorial [TBD?] -->
-
-### Kernel Development
-
-Goal:
-
-- You want to contribute to the seL4 kernel itself.
-- You want to port seL4 to a new platform.
-- You want to add new features to the kernel.
-
-Read this first:
-
-- [Contributing to kernel code](/projects/sel4/kernel-contribution.html)
-
-Then follow these tutorials:
-
-1. [seL4 overview](https://sel4.systems/About/seL4-whitepaper.pdf)
-2. [Introduction tutorial](#introduction-tutorial)
-3. [seL4 mechanisms tutorial](#seL4-mechanisms-tutorials)
-4. [MCS tutorial](#mcs-extensions)
-
-# The Tutorials
-
-## Prerequisites
-
-*  [set up your machine](/GettingStarted#setting-up-your-machine).
-
-### Python Dependencies
-Additional python dependencies are required to build tutorials. To install you can run:
-```
-pip install --user aenum
-pip install --user pyelftools
-```
-
-### Get the code
-```
-mkdir sel4-tutorials-manifest
-cd sel4-tutorials-manifest
-repo init -u https://github.com/seL4/sel4-tutorials-manifest
-repo sync
-```
-
-### Doing the tutorials
-
-The top of the source tree contains the kernel itself, and the tutorials are found in the subfolder: "`projects/sel4-tutorials`". The tutorial consists of some pre-written sample applications which have been deliberately half-written. You will be guided through filling in the missing portions, and thereby become acquainted with seL4. For each of the sample applications however, there is a completed solution that shows all the correct answers, as a reference.
-When completing the tutorials you will be initialising and building your solutions with CMake. The general flow of completing a tutorial exercise involves:
-```
-# creating a Tutorial directory
-mkdir tutorial
-cd tutorial
-# initialising the build directory with a tutorial exercise
-../init --plat <platform> --tut <tutorial exercise>
-# building the tutorial exercise
-ninja
-```
-
-After initialising your directory you will be setup with half-written source for you to complete. Additinally, a build
-directory will be created based on your directory name eg `tutorial_build`.
-
-Your job is to follow the tutorial instructions to complete the application in the tutorial folder.
-
-- The completed sample applications showing the solutions to the
-        tutorial challenges can be retrieved by initialsing a directory with the `--solution` argument
-        e.g. `../init --plat <platform> --tut <tutorial exercise> --solution`
-
-## List of tutorials
-
-### Introduction tutorial
-
-Before starting tutorials, make sure that you have read through the
-[Prerequisites](#prerequisites) and in particular [Doing the
-tutorials](#doing-the-tutorials).
-
-Then, before any other tutorial, do the hello-world tutorial:
-
-{%- for t in tutorials %}
-{%- if t.tutorial-order contains '0-hello' %}
-1. [{{t.title}}]({{t.url}}) {{t.description}}
-{%- endif %}
-{%- endfor %}
-
-which will ensure your setup is working correctly.
-
-### seL4 mechanisms tutorials
-
-This set of tutorials are for people keen to learn about the base mechanisms provided
-by the seL4 kernel. You will learn about the kernel API through small exercises
-that show basic examples.
-
-{% assign tutorials = site.pages | where_exp: 'page', 'page.tutorial' | sort: 'tutorial-order' %}
-{%- for t in tutorials %}
-{%- if t.tutorial-order contains 'mechanisms' %}
-1. [{{t.title}}]({{t.url}}) {{t.description}}
-{%- endif %}
-{%- endfor %}
-
-### Rapid prototyping tutorials
-
-This set of tutorials provides walkthroughs and exercises for using the dynamic
-libraries provided in [seL4_libs](TODO LINK). These libraries are provided as is,
-and have been developed for rapidly prototyping systems on seL4. They have not been
-through intensive quality assurance and do have bugs. Contributions are welcome.
-
-{%- for t in tutorials %}
-{%- if t.tutorial-order contains 'dynamic' %}
-1. [{{t.title}}]({{t.url}}) {{t.description}}
-{%- endif %}
-{%- endfor %}
-
-* The slide presentations to guide you through the tutorials are in the following files:
-
-  - `projects/sel4-tutorials/docs/seL4-Overview.pdf`: This
-            is an overview of the design and thoughts behind seL4, and
-            we strongly recommend you read it before starting
-            the tutorials.
-  - `projects/sel4-tutorials/docs/seL4-APILib-details.pdf`: This is the actual tutorial.
-
-### CAmkES tutorials
-
-These tutorials get you started with our component system CAmkES, which
-allows you to configure static systems through components. CAmkES
-generates the glue code for interacting with seL4 and is designed for building
-high-assurance, static systems.
-
-These tutorials work similarly to the SEL4 tutorials in that they are
-guided by a slide presentation. There are half-completed sample
-applications, with a set of slides giving instructions, with TASK
-challenges once again. There are also completed sample solutions.
-
-{%- for t in tutorials %}
-{%- if t.tutorial-order contains 'camkes' %}
-1. [{{t.title}}]({{t.url}}) {{t.description}}
-{%- endif %}
-{%- endfor %}
-
-- The slide presentations to guide you through the tutorials are
-        in this
-        file: `projects/sel4-tutorials/docs/CAmkESTutorial.pdf`.
-
-### Virtual machines
-
-These tutorials show how to run Linux guests on Camkes and how to communicate between them.
-Currently these tutorials are for x86 only.
-
-{%- for t in tutorials %}
-{%- if t.tutorial-order contains 'vm' %}
-1. [{{t.title}}]({{t.url}}) {{t.description}}
-{%- endif %}
-{%- endfor %}
-
-### MCS extensions
-
-The MCS extensions are upcoming API changes to seL4.
-
-{%- for t in tutorials %}
-{%- if t.tutorial-order contains 'mcs' %}
-1. [{{t.title}}]({{t.url}}) {{t.description}}
-{%- endif %}
-{%- endfor %}
-
-## What next?
-
-You can try building and running [seL4test](../seL4Test).
-
-Next steps include working on one of our [suggested
-projects](/SuggestedProjects.html) or helping to expand the collection
-of [libraries and
-components](/projects/available-user-components.html) available to
-build seL4-based systems.
+<p>
+    Next: <a href="pathways">Pathways through the tutorials</a>
+</p>

--- a/Tutorials/interrupts.md
+++ b/Tutorials/interrupts.md
@@ -2,10 +2,9 @@
 toc: true
 title: Interrupts
 tutorial: interrupts
-tutorial-order: mechanisms-7
-description: receiving and handling interrupts.
+layout: tutorial
+description: receiving and handling interrupts
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/ipc.md
+++ b/Tutorials/ipc.md
@@ -2,8 +2,8 @@
 toc: true
 title: IPC
 tutorial: ipc
-tutorial-order: mechanisms-5
-description: overview of interprocess communication (IPC).
+layout: tutorial
+description: overview of interprocess communication (IPC)
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---

--- a/Tutorials/libraries-1.md
+++ b/Tutorials/libraries-1.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Dynamic Libraries 3
-tutorial: dynamic-3
-tutorial-order: dynamic-3
-description: process management with seL4_libs.
+title: Libraries initialisation & threading
+tutorial: libraries-1
+layout: tutorial
+description: system initialisation & threading with seL4_libs.
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/libraries-2.md
+++ b/Tutorials/libraries-2.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Dynamic Libraries 1
-tutorial: dynamic-1
-tutorial-order: dynamic-1
-description: system initialisation & threading with seL4_libs.
+title: Libraries IPC
+tutorial: libraries-2
+layout: tutorial
+description: IPC with seL4_libs
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/libraries-3.md
+++ b/Tutorials/libraries-3.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Dynamic Libraries 4
-tutorial: dynamic-4
-tutorial-order: dynamic-4
-description: timers and timeouts with seL4_libs.
+title: Libraries processes & ELF loading
+tutorial: libraries-3
+layout: tutorial
+description: process management with seL4_libs
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/libraries-4.md
+++ b/Tutorials/libraries-4.md
@@ -1,11 +1,10 @@
 ---
 toc: true
-title: Dynamic Libraries 2
-tutorial: dynamic-2
-tutorial-order: dynamic-2
-description: IPC with seL4_libs.
+title: Libraries timer tutorial
+tutorial: libraries-4
+layout: tutorial
+description: timers and timeouts with seL4_libs
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/mapping.md
+++ b/Tutorials/mapping.md
@@ -2,8 +2,8 @@
 toc: true
 title: Mapping
 tutorial: mapping
-tutorial-order: mechanisms-3
-description: virtual memory in seL4.
+layout: tutorial
+description: virtual memory in seL4
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---

--- a/Tutorials/mcs.md
+++ b/Tutorials/mcs.md
@@ -2,10 +2,9 @@
 toc: true
 title: MCS
 tutorial: mcs
-tutorial-order: mcs-1
+layout: tutorial
 description: an introduction to the seL4 MCS extensions.
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/notifications.md
+++ b/Tutorials/notifications.md
@@ -2,10 +2,9 @@
 toc: true
 title: Notifications
 tutorial: notifications
-tutorial-order: mechanisms-6
-description: using notification objects and signals.
+layout: tutorial
+description: using notification objects and signals
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 {% include tutorial.md %}
-

--- a/Tutorials/pathways.md
+++ b/Tutorials/pathways.md
@@ -1,0 +1,64 @@
+---
+toc: true
+title: Pathways
+layout: tutorial
+description: pathways through tutorials depending on learning objectives
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
+---
+
+# Pathways through tutorials
+The tutorials can be approached in a number of different ways. Our recommended approach for newcomers is to begin the [Microkit](https://trustworthy.systems/projects/microkit/tutorial/), bearing in mind that the Microkit hides many of the seL4 mechanisms - it is designed that way, to make building on top of seL4 easier. Having built a small system on top of seL4, the developer can delve into the concepts in the order list in the navigation bar to the left.
+
+## Alternate pathways
+Alternate pathways through the tutorials depend on development goals.
+
+### Evaluation
+Goals
+- to understand seL4 and its benefits
+- to learn how to use seL4 to develop trustworthy systems
+- to see, compile, and run some code
+
+Recommended tutorials
+- [Setting up your machine](setting-up.md)
+- [Getting the tutorials](get-the-tutorials.md)
+- [Hello world](hello-world.md)
+
+### System Building
+Goals
+- to build systems based on seL4
+- to know which tools are available to build systems, and how to use those tools
+- to build trustworthy systems
+
+Recommended tutorials
+- [Setting up your machine](setting-up.md)
+- [Getting the tutorials](get-the-tutorials.md)
+- [Hello world](hello-world.md)
+- [MCS](mcs.md)
+- The CAmkES tutorials beginning with [Hello CAmkES](hello-camkes-0.md)
+- Virtualisation tutorials
+  - [CAmkES VM](../CAmkES/camkes-vm-linux) using Linux as a guest in the CAmkES VM; and
+  - [CAmkES Cross-VM communication](camkes-vm-crossvm.md) walkthrough of adding communication between Linux guests in separate VMs
+
+
+### Platform Development
+Goals
+- to contribute to development of the seL4 (user-level) platform
+- to develop operating system services and device drivers
+- to develop seL4-based frameworks and operating systems
+
+Recommended tutorials
+To gain a comprehensive understanding of seL4, we recommend that you go through all the tutorials in the order listed in the default pathway.
+
+
+### Kernel Development
+Goals
+- to contribute to the seL4 kernel itself
+- to port seL4 to a new platform
+- to add new features to the kernel
+
+Recommended reading
+- [Contributing to kernel code](../../projects/sel4/kernel-contribution)
+
+Recommended tutorials
+- Follow the tutorial in the default pathway up to and including MCS.

--- a/Tutorials/setting-up.md
+++ b/Tutorials/setting-up.md
@@ -1,0 +1,154 @@
+---
+toc: true
+layout: tutorial
+description: guide to machine set-up for tutorials
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
+---
+
+# Setting up your machine
+
+## Google's Repo tool
+
+The primary way of obtaining and managing seL4 project sources is through the use of Google's Repo tool.
+
+To install run:
+```sh
+  sudo apt-get update
+  sudo apt-get install repo
+```
+
+<details markdown='1'>
+<summary>More on Repo</summary>
+<br>
+[More details about on installing Repo](https://source.android.com/setup/develop#installing-repo).
+
+[seL4 Repo cheatsheet](../projects/buildsystem/repo-cheatsheet)
+</details>
+
+## Docker
+To compile and use seL4, it is recommended that you use Docker to isolate the dependencies from your machine.
+
+These instructions assume you are using Debian (or a derivative, such as Ubuntu), and are using Bash for your shell. However, it should be informative enough for users of other distros/shells to adapt.
+
+These instructions are intended for Ubuntu LTS versions 20.04 and 22.04.
+
+To begin, you will need at least these two programs:
+
+ * make (`sudo apt install make`)
+ * docker (See [here](https://get.docker.com) or [here](https://docs.docker.com/engine/installation) for installation instructions)
+
+For convenience, add your account to the docker group:
+
+```bash
+sudo usermod -aG docker $(whoami)
+```
+
+<details markdown='1'>
+  <summary>More on Docker</summary>
+  <br>
+
+  **Available images**
+
+  All the prebuilt docker images are available on [DockerHub here](https://hub.docker.com/u/trustworthysystems)
+
+  These images are used by the Trustworthy Systems Continuous Integration (CI) software, and so represent a standard software setup we use.
+  The CI software always uses the `latest` docker image, but images are also tagged with the date they were built.
+
+  **More information**
+
+  You can find the dockerfiles and supporting Makefile [here](https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles)
+
+</details>
+
+
+### Getting a build environment
+To get a running build environment for seL4 and CAmkES, run:
+
+```bash
+git clone https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles.git
+cd seL4-CAmkES-L4v-dockerfiles
+make user
+```
+
+This will give you a terminal inside a container that has all the relevant tools to build, simulate, and test seL4 & Camkes programs.
+
+The first time you run this, docker will fetch the relevant images, which may take a while.
+
+The last line will say something like:
+
+```
+Hello, welcome to the seL4/CAmkES/L4v docker build environment
+```
+
+### Mapping a container
+To run the container from other directories (e.g. starting a container for the [Hello World](hello-world.md) tutorial, which we'll do next), you can setup a bash alias such as this:
+
+```bash
+echo $'alias container=\'make -C /<path>/<to>/seL4-CAmkES-L4v-dockerfiles user HOST_DIR=$(pwd)\'' >> ~/.bashrc
+# now open a new terminal, or run `source ~/.bashrc`
+```
+
+Replace `/<path>/<to>/` to match where you cloned the git repo of the docker files.
+
+*Reminder:* Include the absolute path to your `seL4-CAmkES-L4v-dockerfiles` folder, e.g.
+
+```bash
+echo $'alias container=\'make -C /~/seL4-CAmkES-L4v-dockerfiles user HOST_DIR=$(pwd)\'' >> ~/.bashrc
+# now open a new terminal, or run `source ~/.bashrc`
+
+```
+
+This then allows you to run `container` from any directory.
+
+*Reminder:* start a new terminal for the changes in `.bashrc` to take effect or run `source ~/.bashrc`.
+
+
+## An example workflow
+
+A good workflow is to run two terminals:
+
+ - Terminal A is just a normal terminal, and is used for git operations, editing (e.g., vim, emacs, vscode), and other non-build operations.
+ - Terminal B is running in a container, and is only used for compilation.
+
+This gives you the flexibility to use all the normal tools you are used to, while having the seL4 dependencies separated from your machine.
+
+### Compiling seL4 test
+
+Start two terminals (terminal A and terminal B).
+
+In terminal A, run these commands:
+
+```bash
+jblogs@host:~$ mkdir ~/seL4test
+jblogs@host:~$ cd ~/seL4test
+jblogs@host:~/seL4test$ repo init -u https://github.com/seL4/seL4test-manifest.git
+jblogs@host:~/seL4test$ repo sync
+```
+
+In terminal B, run these commands:
+
+```bash
+jblogs@host:~$ cd ~/seL4test
+jblogs@host:~/seL4test$ container  # using the bash alias defined above
+jblogs@in-container:/host$ mkdir build-x86
+jblogs@in-container:/host$ cd build-x86
+jblogs@in-container:/host/build-x86$ ../init-build.sh -DPLATFORM=x86_64 -DSIMULATION=TRUE
+jblogs@in-container:/host/build-x86$ ninja
+jblogs@in-container:/host/build-x86$ ./simulate
+```
+
+If you need to make any code modifications or commit things to git, use terminal A. If you need to recompile or simulate an image, use terminal B.
+
+`./simulate` is run using [QEMU](https://www.qemu.org/), and will take a few minutes to run. If QEMU works, you'll see something like
+
+```
+Test suite passed. 121 tests passed. 57 tests disabled.
+All is well in the universe
+```
+
+Note, if QEMU fails when trying to simulate the image, try configuring your Docker host to give the container more memory using [Docker Desktop](https://docs.docker.com/desktop/use-desktop/).
+
+That's it! seL4 is running.
+
+To quit QEMU: `Ctrl+a, x`

--- a/Tutorials/threads.md
+++ b/Tutorials/threads.md
@@ -2,8 +2,8 @@
 toc: true
 title: Threads
 tutorial: threads
-tutorial-order: mechanisms-4
-description: how to start a thread using the seL4 API.
+layout: tutorial
+description: how to start a thread using the seL4 API
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---

--- a/Tutorials/untyped.md
+++ b/Tutorials/untyped.md
@@ -2,8 +2,8 @@
 toc: true
 title: Untyped
 tutorial: untyped
-tutorial-order: mechanisms-2
-description: user-level memory management.
+layout: tutorial
+description: user-level memory management
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---

--- a/_data/projects/sel4-tutorials.yml
+++ b/_data/projects/sel4-tutorials.yml
@@ -12,6 +12,10 @@ repositories:
   - org: sel4proj
     repo: sel4-tutorials-manifest
 
+# The order of the components list determines the order of the tutorials in the
+# tutorial nav side bar. The field section is used there to include groups of
+# tutorials.
+
 components:
   - name: hello-world
     display_name: "Hello world"
@@ -19,120 +23,160 @@ components:
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
-  - name: hello-camkes-0
-    display_name: "CAmkES"
-    description: "The first CAmkES application to run"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: hello-camkes-1
-    display_name: "CAmkES 1"
-    description: "CAmkES ADL and RPC interface tutorial"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: hello-camkes-2
-    display_name: "CAmkES 2"
-    description: "CAmkES event and dataport tutorial"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: hello-camkes-timer
-    display_name: "CAmkES timer"
-    description: "CAmkES tutorial for accessing hardware"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: dynamic-1
-    display_name: "Dynamic Libraries 1"
-    description: "Initialisation and threading tutorial"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: dynamic-2
-    display_name: "Dynamic Libraries 2"
-    description: "seL4 IPC and userspace paging management tutorial"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: dynamic-3
-    display_name: "Dynamic Libraries 3"
-    description: "Processes and ELF loading tutorial"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: dynamic-4
-    display_name: "Dynamic Libraries 4"
-    description: "Tutorial for using device drivers"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
-  - name: mcs
-    display_name: "MCS"
-    description: "MCS extension tutorial"
-    maintainer: "seL4 Foundation"
-    status: "active"
-    component_type: sel4-tutorials-application
+    section: sel4
+
   - name: capabilities
     display_name: "Capabilities"
     description: "seL4 capabilities tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: untyped
     display_name: "Untyped"
     description: "Physical memory management tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: mapping
     display_name: "Mapping"
     description: "Virtual memory management tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: threads
     display_name: "Threads"
     description: "Threads on seL4 tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: ipc
     display_name: "IPC"
     description: "seL4 IPC tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: notifications
-    display_name: "Notification"
+    display_name: "Notifications"
     description: "seL4 notification tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: interrupts
     display_name: "Interrupts"
     description: "Tutorial for accessing interrupts on seL4"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
   - name: fault-handlers
     display_name: "Fault handling"
     description: "Fault handling tutorial"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: sel4
+
+  - name: mcs
+    display_name: "MCS extensions"
+    description: "MCS extension tutorial"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: sel4
+
+  - name: libraries-1
+    display_name: "Initialisation &amp; threading"
+    description: "Initialisation and threading tutorial"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: libraries
+
+  - name: libraries-2
+    display_name: "IPC"
+    description: "seL4 IPC and userspace paging management tutorial"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: libraries
+
+  - name: libraries-3
+    display_name: "Processes &amp; Elf loading"
+    description: "Processes and ELF loading tutorial"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: libraries
+
+  - name: libraries-4
+    display_name: "Timer"
+    description: "Tutorial for using device drivers"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: libraries
+
+  - name: hello-camkes-0
+    display_name: "Hello CAmkES"
+    description: "The first CAmkES application to run"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: camkes
+
+  - name: hello-camkes-1
+    display_name: "Introduction to CAmkES"
+    description: "CAmkES ADL and RPC interface tutorial"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: camkes
+
+  - name: hello-camkes-2
+    display_name: "Events in CAmkES"
+    description: "CAmkES event and dataport tutorial"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: camkes
+
+  - name: hello-camkes-timer
+    display_name: "CAmkES timer tutorial"
+    description: "CAmkES tutorial for accessing hardware"
+    maintainer: "seL4 Foundation"
+    status: "active"
+    component_type: sel4-tutorials-application
+    section: camkes
+
   - name: camkes-vm-linux
-    display_name: "CAmkES VM Linux"
+    display_name: "CAmkES VM"
     description: "Tutorial for creating VM guests and applications on seL4 using CAmkES"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: camkes
+
   - name: camkes-vm-crossvm
-    display_name: "CAmkES cross-VM communication"
-    description: "Tutorial for using cross virtual machine connector"
+    display_name: "CAmkES cross-VM connectors"
+    description: "Tutorial for using cross virtual machine connectors"
     maintainer: "seL4 Foundation"
     status: "active"
     component_type: sel4-tutorials-application
+    section: camkes
+
   - name: libsel4tutorials
     display_name: "libsel4tutorials"
     description: "Utility Library for doing seL4 tutorials"

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -2,11 +2,11 @@
 # Copyright 2020 seL4 Project a Series of LF Projects, LLC.
 
 toc:
-  - title: Getting Started
-    url: /GettingStarted.html
+  - title: Resources
+    url: /Resources.html
     subfolderitems:
-      - page: Getting Started
-        url: /GettingStarted.html
+      - page: Resources
+        url: /Resources.html
       - page: seL4 Documentation
         url: /projects/sel4/documentation.html
       - page: seL4 FAQ

--- a/_data/tutorials-sidebar.yml
+++ b/_data/tutorials-sidebar.yml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: CC-BY-SA-4.0
+# Copyright 2024 seL4 Project a Series of LF Projects, LLC.
+
+# nav side bar for tutorials
+#
+# refers to sections from projects/sel4-tutorials.yml via the "section" field
+# there, and "include" field here.
+
+- name: Getting started
+  type: header
+- name: Overview
+  file: ""
+  type: file
+- name: Tutorial pathways
+  file: pathways
+  type: file
+
+- name: seL4
+  type: header
+- name: Setting up your machine
+  file: setting-up
+  type: file
+- name: Getting the tutorials
+  file: get-the-tutorials
+  type: file
+- name: sel4
+  type: include
+
+- name: C Libraries
+  type: header
+- name: libraries
+  type: include
+
+- name: Microkit
+  type: header
+- name: Tutorial
+  url: https://trustworthy.systems/projects/microkit/tutorial/
+  type: url
+
+- name: CAmkES
+  type: header
+- name: camkes
+  type: include
+
+- name: Rust
+  type: header
+- name: GitHub
+  url: https://github.com/seL4/rust-sel4
+  type: url
+
+- name: Resources
+  type: header
+- name: seL4 Manual
+  url: https://sel4.systems/Info/Docs/seL4-manual-latest.pdf
+  type: url
+- name: seL4 API reference
+  url: /projects/sel4/api-doc.html
+  type: url
+- name: "How to: a quick solutions guide"
+  file: how-to
+  type: file
+- name: Debugging guide
+  url: /projects/sel4-tutorials/debugging-guide
+  type: url
+- name: Help contacts
+  url: "/Resources#contact"
+  type: url

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,10 +16,10 @@ This header is responsible for the seL4 logo and top h2 links.
     </li>
     <li class="col-xs-12 col-md-10 menu">
       <nav aria-label="Banner links">
-        <h2><a href="/GettingStarted">Getting Started</a></h2>
-        <h2><a href="/processes">Contributing</a></h2>
-        <h2><a href="/projects">Projects</a></h2>
-        <h2><a href="/Tutorials">Tutorials</a></h2>
+        <h2><a href="{{ '/Resources' | relative_url }}" />Resources</h2>
+        <h2><a href="{{ '/processes' | relative_url }}" />Contributing</a></h2>
+        <h2><a href="{{ '/Projects' | relative_url }}" />Projects</h2>
+        <h2><a href="{{ '/Tutorials' | relative_url }}" />Tutorials</h2>
         <iframe title="DuckDuckGo search bar" src="https://duckduckgo.com/search.html?site=docs.sel4.systems&prefill=Search%20sel4.systems" style="overflow:hidden;margin-bottom:10px; padding:0;height:40px;float:right;border-width: 0px"></iframe>
       </nav>
     </li>

--- a/_includes/nav-sidebar.html
+++ b/_includes/nav-sidebar.html
@@ -11,7 +11,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
       <ul class="nav nav-sidebar">
   {% for entry in item.subfolderitems %}
         <li class="{% if page.url == entry.url %}active{% endif %}">
-          <a class="" href="{{ entry.url }}">
+          <a class="" href="{{ entry.url | relative_url }}">
             {{ entry.page }}
           </a>
         </li>
@@ -49,20 +49,9 @@ executed for production builds. This is all so the project links can be sorted
     {% assign url = "/projects/" | append: new_project[0].name | append: '/' %}
         <li class="{% if page_url[2] == new_project[0].name %}active{% endif %}">
             <a class="" href="{{url}}">{{new_project[0].display_name}}</a>
-        <li>
+        </li>
   {% endfor %}
     </ul>
 {% endif %}
 
-
-{% if page_url[1] == "Tutorials" %}
-    <ul class="nav nav-sidebar">
-  {% assign tutorials = site.pages | where_exp: 'page', 'page.tutorial' | sort: 'tutorial-order' %}
-  {% for t in tutorials %}
-        <li class="{% if page.url == t.url %}active{% endif %}">
-            <a class="" href="{{t.url}}">{{t.title}}</a>
-        <li>
-  {% endfor %}
-    </ul>
-{% endif %}
 </div>

--- a/_includes/tutorial.md
+++ b/_includes/tutorial.md
@@ -3,15 +3,4 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 {% endcomment %}
 
-{% capture path %}
-{{page.tutorial}}/{{page.tutorial}}.md
-{% endcapture %}
-
-{% assign view_url = 'https://github.com/sel4/' | append: "sel4-tutorials" | append: '/blob/master/tutorials/' | append: path %}
-{% assign edit_url = 'https://github.com/sel4/' | append: "sel4-tutorials" | append: '/edit/master/tutorials/' | append: path %}
-
 {% include_absolute _repos/tutes/{{page.tutorial}}.md %}
-
--------------
-
-*Tutorial included from [github repo]({{view_url}}) [edit]({{edit_url}})*

--- a/_includes/tutorials-sidebar.html
+++ b/_includes/tutorials-sidebar.html
@@ -1,0 +1,23 @@
+{% comment %}
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2024 seL4 Project a Series of LF Projects, LLC.
+{% endcomment %}
+
+<div class="sidebar">
+  <ul class="nav nav-sidebar tutorial-sidebar">
+{%- for item in all_tutes -%}
+{%-   case item.type -%}
+{%-     when "header" %}
+    <li class="nav-section">{{ item. name}}</li>
+{%-     when "file" -%}
+{%-       assign url = "/Tutorials/" | append: item.file | relative_url %}
+      <li><a href="{{ url }}">{{ item.name }}</a></li>
+{%-     when "url" %}
+      <li><a href="{{ item.url | relative_url }}">{{ item.name }}</a></li>
+{%-     else -%}
+{%-       assign url = "/Tutorials/" | append: item.name | relative_url %}
+      <li><a href="{{ url }}">{{ item.display_name }}</a></li>
+{%-   endcase -%}
+{%- endfor %}
+  </ul>
+</div>

--- a/_layouts/overview.html
+++ b/_layouts/overview.html
@@ -1,0 +1,28 @@
+---
+layout: basic
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
+---
+
+<div class="row">
+  <div class="hidden-xs col-sm-4 col-md-3 col-lg-2">
+    {% include nav-sidebar.html %}
+
+  </div>
+  <div class="content col-sm-8 col-md-6 col-lg-7 main">
+    {{ content }}
+  </div>
+
+{% assign url = page.url | split: "/" %}
+{% capture project_name %}
+{% if page.project %}
+{{page.project}}
+{% elsif url[1] == "projects" %}
+{{url[2]}}
+{% endif %}
+{% endcapture %}
+
+{% assign project_name = project_name | strip %}
+{% assign project = site.data.projects[project_name] %}
+
+</div>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -1,0 +1,86 @@
+---
+layout: basic
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
+---
+
+{%- assign components = site.data.projects["sel4-tutorials"].components -%}
+{%- assign all_tutes = "" | split: "." -%}
+{%- for item in site.data.tutorials-sidebar -%}
+{%-   if item.type == "include" -%}
+{%-     for component in components -%}
+{%-       if component.section == item.name -%}
+{%-         assign all_tutes = all_tutes | push: component -%}
+{%-       endif -%}
+{%-     endfor -%}
+{%-   else -%}
+{%-     assign all_tutes = all_tutes | push: item -%}
+{%-   endif -%}
+{%- endfor -%}
+
+<div class="row">
+  <div class="hidden-xs col-sm-4 col-md-3 col-lg-2">
+    {% include tutorials-sidebar.html %}
+  </div>
+  <div class="content col-sm-8 col-md-6 col-lg-7 main">
+
+    {{ content }}
+
+<p style="text-align: right;">
+{%  assign page_file = page.url | split: '/' | last | remove: ".html" -%}
+{%- assign found = false -%}
+{%- for item in all_tutes -%}
+{%-   if found -%}
+{%-     if item.type == "header" -%}
+{%- comment -%}
+          We include the preceding header name in the "next" link when the link
+          is an offsite URL, e.g. for Microkit or Rust.
+{%- endcomment -%}
+{%-       assign header_name = item.name -%}
+{%-     else -%}
+{%-       case item.type -%}
+{%-         when "file" -%}
+{%-           assign url = "/Tutorials/" | append: item.file | relative_url %}
+      Next: <a href="{{ url }}">{{ item.name }}</a>
+{%-         when "url" -%}
+{%-         else -%}
+{%-           assign url = "/Tutorials/" | append: item.name | relative_url %}
+      Next: <a href="{{ url }}">{{ item.display_name }}</a>
+{%-       endcase -%}
+{%-       break -%}
+{%-     endif -%}
+{%-   else -%}
+{%-     case item.type -%}
+{%-       when "file" -%}
+{%-         if item.file == page_file -%}
+{%-           assign found = true -%}
+{%-         endif -%}
+{%-       when "url" -%}
+{%-       when "header" -%}
+{%-       else -%}
+{%-         if item.name == page_file -%}
+{%-           assign found = true -%}
+{%-         endif -%}
+{%-     endcase -%}
+{%-   endif -%}
+{%- endfor %}
+</p>
+
+{% if page.tutorial -%}
+  {%- capture path -%}
+  {{page.tutorial}}/{{page.tutorial}}.md
+  {%- endcapture -%}
+
+  {%- assign repo_url = 'https://github.com/sel4/sel4-tutorials' -%}
+  {%- assign view_url = repo_url | append: '/blob/master/tutorials/' | append: path -%}
+  {%- assign edit_url = repo_url | append: '/edit/master/tutorials/' | append: path -%}
+    <hr>
+    <p><em>Tutorial included from <a href="{{view_url}}">github repo</a> <a href="{{edit_url}}">edit</a></em></p>
+{%- endif %}
+  </div>
+
+  {% if page.toc %}
+    {% include toc-sidebar.html %}
+  {% endif %}
+</div>
+<script src="{{ '/assets/js/toggle-markdown.js' | relative_url }}"></script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -252,6 +252,20 @@ h2 a,
   background-color: #428bca;
 }
 
+.tutorial-sidebar li {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.tutorial-sidebar li > a {
+  padding-bottom: 0.5ex;
+  padding-top: 0.5ex;
+}
+
+li.nav-section {
+  padding-top: 1ex;
+  font-weight: bold;
+}
+
 /* This adds a unicode character corresponding to .fa-external-link-alt from fontawesome
    to every external link */
 a[href*="//"]:not([href*="{{site.url}}"],.skip-icon):after {
@@ -290,4 +304,15 @@ a[href*="//"]:not([href*="{{site.url}}"],.skip-icon):after {
 }
 .flex-grid-thirds .col {
   width: 32%;
+}
+
+/* tutorials solutions boxes */
+details {
+  padding-bottom: 20px;
+}
+summary {
+    display:list-item;
+}
+details > summary {
+  cursor: pointer;
 }

--- a/assets/js/toggle-markdown.js
+++ b/assets/js/toggle-markdown.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
+// Copyright 2024 seL4 Project a Series of LF Projects, LLC.
+
+// Expand all solutions
+let param = new URLSearchParams(window.location.search);
+
+if (param.has('tut_expand')) {
+        document.body.querySelectorAll('details').forEach((e) => {
+        e.setAttribute('open', true);
+    })
+}

--- a/content_collections/_updates/sel4-tutorials/camkes-3.8.x.md
+++ b/content_collections/_updates/sel4-tutorials/camkes-3.8.x.md
@@ -16,7 +16,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 - `interrupts`: Remove sample output that doesn't appear in practice.
 - `hello-camkes-2`: Update exit text test to match actual output.
 - `mcs`: reduce spinner budget for final task to ensure timeout behavior happens correctly.
-- `dynamic-4`: Correctly initalize a stack variable.
+- `libraries-4`: Correctly initalize a stack variable.
 - `hello-camkes-timer`: Use device tree for binding timer component to device and update tutorial.
 - `hello-camkes-timer`: Add part-2 to tutorial for describing how to use new seL4DTBHardware camkes connector.
 - `camkes-vm-crossvm`: Add error message if build configuration is incorrect.
@@ -24,10 +24,10 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 - `hello-camkes-2`: Fix error in hint in task 8.
 - Refactor tutorial build system to better match typical usage in other project. Previously the tutorials indicated
   that their build scripts shouldn't be used outside of the tutorial project, but this is no longer the case.
-- `dynamic-4`: Update platform timer API's to use ltimer interface.
+- `libraries-4`: Update platform timer API's to use ltimer interface.
 - `mcs`: Support running tutorial on kernel master branch since mcs branch was merged.
 - `mapping`: Remove seL4_X86_Page_Remap invocation from tutorial as kernel function had been removed.
-- `dynamic-1`: fix completion text for task-3.
+- `libraries-1`: fix completion text for task-3.
 - `hello-camkes-1`: Update instructions to match source code layout.
 - `untyped`: Make sure that untyped being used in tutorial doesn't correspond to a device.
 

--- a/index.md
+++ b/index.md
@@ -12,18 +12,18 @@ This documentation site is for cooperatively developing and sharing documentatio
 </div>
 
 
- <div class="flex-grid">
+<div class="flex-grid">
   <div class="col">
-   <h1><a href="/GettingStarted">Getting started</a></h1>
+   <h1><a href="/Resources">Resources</a></h1>
 	<p>Information about working with seL4 and its ecosystem</p>
 	<ul>
-	<li><a href="/GettingStarted#background-and-terminology">seL4 Background</a></li>
+	<li><a href="/Resources#background-and-terminology">seL4 Background</a></li>
 	<li><a href="/MaintainedRepositories">The source code</a></li>
 	<li><a href="/projects/sel4/documentation.html">Documentation</a></li>
 	<li><a href="/projects/sel4/frequently-asked-questions.html">Frequently Asked Questions (FAQ)</a></li>
 	<li><a href="/projects/roadmap.html">Roadmap</a></li>
 	<li><a href="/projects/buildsystem/host-dependencies.html">Build dependencies</a></li>
-	<li><a href="/GettingStarted#running-sel4">Building and Running seL4</a></li>
+	<li><a href="/Resources#running-sel4">Building and Running seL4</a></li>
 	<li><a href="/Hardware">Supported platforms</a></li>
 	<li><a href="/projects/sel4/verified-configurations.html">Verification targets and claims</a></li>
 	</ul>
@@ -41,39 +41,36 @@ This documentation site is for cooperatively developing and sharing documentatio
         <li><a href="/processes/style-guide.html">Style Guide</a></li>
 	</ul>
   </div>
- </div>
- <div class="flex-grid" >
+</div>
+<div class="flex-grid">
   <div class="col ">
-   <h1><a href="/projects/">Projects</a></h1>
-	<p>List and details of all the projects that make up the seL4 platform.</p>
-
-	<ul>
-        <li><a href="/projects/sel4/">seL4 kernel</a></li>
-        <li><a href="/projects/l4v/">L4.verified</a></li>
-        <li><a href="/projects/microkit/">seL4 Microkit</a></li>
-        <li><a href="/projects/camkes/">CAmkES</a></li>
-        <li><a href="/projects/sel4test/">seL4test</a></li>
-        <li><a href="/projects/sel4bench/">seL4bench</a></li>
-        <li><a href="/projects/virtualization/">Virtualisation</a></li>
-        <li><a href="/projects/buildsystem/">Build System</a></li>
-        <li><a href="/projects/sel4webserver/">Example system: seL4webserver</a></li>
-	</ul>
-  </div>
+    <h1><a href="/projects/">Projects</a></h1>
+    <p>List and details of all the projects that make up the seL4 platform.</p>
+    <ul>
+          <li><a href="/projects/sel4/">seL4 kernel</a></li>
+          <li><a href="/projects/l4v/">L4.verified</a></li>
+          <li><a href="/projects/microkit/">seL4 Microkit</a></li>
+          <li><a href="/projects/camkes/">CAmkES</a></li>
+          <li><a href="/projects/sel4test/">seL4test</a></li>
+          <li><a href="/projects/sel4bench/">seL4bench</a></li>
+          <li><a href="/projects/virtualization/">Virtualisation</a></li>
+          <li><a href="/projects/buildsystem/">Build System</a></li>
+          <li><a href="/projects/sel4webserver/">Example system: seL4webserver</a></li>
+    </ul>
+    </div>
   <div class="col">
-   <h1><a href="/Tutorials/">Tutorials</a></h1>
-	<p>Tutorials and other material to learn about seL4.</p>
-
-	<ul>
-	<li><a href="/Tutorials#how-to-use-the-tutorials">Tutorial overview</a></li>
-	<li><a href="/Tutorials#introduction-tutorial">Introduction (hello world)</a></li>
-	<li><a href="/Tutorials#sel4-mechanisms-tutorials">seL4 mechanisms</a></li>
-	<li><a href="/Tutorials#camkes-tutorials">CAmkES</a></li>
-	<li><a href="/Tutorials#rapid-prototyping-tutorials">Rapid prototyping</a></li>
-	<li><a href="/Tutorials#virtual-machines">Virtual machines</a></li>
-	<li><a href="/Tutorials#mcs-extensions">MCS extensions</a></li>
-	</ul>
+    <h1><a href="/Tutorials/">Tutorials</a></h1>
+    <p>Tutorials and other material to learn about seL4.</p>
+    <ul>
+        <li><a href="/Tutorials/">Overview</a></li>
+        <li><a href="/Tutorials/mcs">MCS</a></li>
+        <li><a href="/Tutorials/libraries-1">Libraries</a></li>
+        <li><a href="/Tutorials/hello-camkes-0">CAmkES</a></li>
+        <li><a href="/Tutorials/how-to"><em>How to:</em> A quick solutions guide to the tutorials</a></li>
+        <li><a href="https://sel4.systems/Info/Docs/seL4-manual-latest.pdf">seL4 Manual</a></li>
+        <li><a href="/projects/sel4/api-doc">API reference</a></li>
+        <li><a href="https://trustworthy.systems/projects/microkit/tutorial/">Microkit</a></li>
+        <li><a href="https://github.com/seL4/rust-sel4">Rust</a></li>
+    </ul>
   </div>
- </div>
-
-
-
+</div>

--- a/projects/buildsystem/index.md
+++ b/projects/buildsystem/index.md
@@ -35,9 +35,9 @@ the actual build.
 It is assumed that
 
  * CMake of an appropriate version is installed
- * You are using the Ninja CMake generator 
+ * You are using the Ninja CMake generator
  * You understand how to checkout projects using the repo tool as described on the
-   [Getting started](/GettingStarted) page
+   [Resources](/Resources) page
  * You have the [required dependencies](/HostDependencies) installed to build your project.
 
 

--- a/projects/camkes/index.md
+++ b/projects/camkes/index.md
@@ -30,7 +30,7 @@ The development framework provides:
 
 ## Get Camkes
 
-- Make sure that you already have the tools to [build seL4 and Camkes](/GettingStarted#setting-up-your-machine).
+- Make sure that you already have the tools to [build seL4 and Camkes](/Resources#setting-up-your-machine).
 - Download Camkes:
 
 ```
@@ -58,7 +58,7 @@ ninja
 
 
 To learn about developing your own CAmkES application, read the
-[Tutorials#CAmkES_tutorials](/Tutorials#camkes-tutorials).
+[Tutorials#CAmkES_tutorials](/tutorials#camkes-tutorials).
 
 ## Camkes Terminology/Glossary
 

--- a/projects/sel4-tutorials/debugging-guide.md
+++ b/projects/sel4-tutorials/debugging-guide.md
@@ -2,6 +2,7 @@
 toc: true
 redirect_from:
   - /DebuggingGuide
+layout: tutorial
 SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---

--- a/projects/sel4/documentation.md
+++ b/projects/sel4/documentation.md
@@ -11,7 +11,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 - [Technical overview paper](https://trustworthy.systems/publications/nictaabstracts/Klein_AEMSKH_14.abstract)
 - [L4 Microkernels: The Lessons from 20 Years of Research and Deployment](https://trustworthy.systems/publications/nictaabstracts/Heiser_Elphinstone_16.abstract),
   a retrospective explaining how we got to where we are;
-- [Getting started](/GettingStarted)
+- [Resources](/Resources)
 - [Trustworthy Systems seL4
       research project pages](https://trustworthy.systems/projects/seL4/)
 - [UNSW Advanced OS lecture slides](https://www.cse.unsw.edu.au/~cs9242/14/lectures/), especialy the Introduction and

--- a/projects/sel4/frequently-asked-questions.md
+++ b/projects/sel4/frequently-asked-questions.md
@@ -627,7 +627,7 @@ There are two recommended ways to do this.
       processes, but is generally more low-level.
 
 For build instructions, and how to get started, see the
-[Getting started](/GettingStarted) page.
+[Resources](/Resources) page.
 Also, UNSW's [Advanced Operating Systems course](https://www.cse.unsw.edu.au/~cs9242) has an extensive project component that
 builds an OS on top of seL4. If you have access to an [Odroid-C2](https://www.hardkernel.com/shop/odroid-c2/),
 you should be able to do the project work yourself as a way of


### PR DESCRIPTION
**Aim:** Arrange the tutorial material such that it is clear and easy to follow
**Solution:** Inspired by the Rust book https://doc.rust-lang.org/book/, the user can see the chapters in the index on the left, and go straight to the sections that they need

Specifically, updated tutorials with: 
  - a streamlined guide to completing the tutorials
  - a streamlined "setting up your machine" page
  - a how-to page with solutions to tutorial questions
  - more organised landing page

To-dos:
 - The new tutorial md files *are not* those from the tutorials repo. The md files in the tutorials repo need to be updated to match the tutorials in this PR, which include solutions and corrections. The new tutorial md files then need to be rewritten as includes to read in the md files from the tutorials repo.
 - Sections on the docsite, other than the tutorials, need to be streamlined