### PR TITLE
style: update astyle version

### DIFF
--- a/processes/style-guide.md
+++ b/processes/style-guide.md
@@ -35,7 +35,7 @@ Code should compile without warnings, with `-Wall`.
 ### Automatic formatting
 
 For automatic formatting of C code, we use
-[astyle](http://astyle.sourceforge.net/), version 2.05.1, with the
+[astyle](http://astyle.sourceforge.net/), version 3.1, with the
 settings declared in our
 [astylerc](https://github.com/seL4/seL4_tools/blob/master/misc/astylerc).
 


### PR DESCRIPTION
3.1 is the version available in Ubuntu 20.04LTS, which is recommended in the current install instructions. Later versions also work and output seems to be stable for our sources. Versions earlier than 3.0 no longer work correctly with the options in our .astylerc.