### PR TITLE
css: use scss comment syntax

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,7 +1,5 @@
----
-# This file is normally provided by our theme.  If this file is deleted,
-# the theme one will transparently replace it.
----
+// This file is normally provided by our theme.  If this file is deleted,
+// the theme one will transparently replace it.
 
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright 2020 seL4 Project a Series of LF Projects, LLC.


### PR DESCRIPTION
It looks like more recent sass versions don't like the `---` preamble and/or it doesn't get properly stripped before it gets to sass.