### PR TITLE
config: fix bootstrap theme version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,7 +83,7 @@ defaults:
 # The jekyll-theme-bootstrap dependency probably contributes the most files to site generation, so it would
 # be the first place to look if something weird is happening with layout/theming.
 # This theme provides a sass port of bootstrap that is imported using our assets/css/style.scss file.
-remote_theme: matrixfox/jekyll-theme-bootstrap
+remote_theme: matrixfox/jekyll-theme-bootstrap@v0.0.5
 markdown: Kramdown
 
 plugins:


### PR DESCRIPTION
https://github.com/matrixfox/jekyll-theme-bootstrap/commits/master/ has new commits which break the build. Fix version to v0.0.5, which is what we've been running all this time.