### PR TITLE
remove warnings

### DIFF
--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -88,7 +88,7 @@ seL4 has support for select ARMv7 and ARMv8 Platforms.
 | - | - | - | - | - | - | - | - | - |
 {%- assign sorted = site.pages | sort: 'platform' %}
 {% for page in sorted %}
-{%- if page.arm_hardware and page.Maintained != "No"" -%}
+{%- if page.arm_hardware and page.Maintained != "No" -%}
 | [{{ page.platform }}]({{page.url}}) | {{ page.soc}} | {{ page.cpu }} | {{ page.arch }} | {{ page.virtualization }} | {{ page.iommu}} | {{ page.Status }} | {{ page.Contrib }} | {{page.Maintained}} |
 {% endif %}
 {%- endfor %}

--- a/_plugins/include_absolute.rb
+++ b/_plugins/include_absolute.rb
@@ -68,7 +68,7 @@ module Jekyll
     end
 
     def read_file(file, context)
-      File.read(file, file_read_opts(context))
+      File.read(file, **file_read_opts(context))
     end
 
     def file_read_opts(context)


### PR DESCRIPTION
- address Ruby "Using the last argument as keyword parameters is deprecated" warning
- fix the Liquid syntax error that was drowned out by those warnings