### PR TITLE
Add downloads section for Microkit SDK

### DIFF
--- a/_data/projects/microkit.yml
+++ b/_data/projects/microkit.yml
@@ -21,3 +21,13 @@ repositories:
     repo: microkit
   - org: au-ts
     repo: microkit_tutorial
+
+sdk_downloads:
+  - version: 1.3.0
+    sdks:
+    - label: "microkit-sdk-1.3.0-linux-x86-64.tar.gz"
+      url: "https://github.com/seL4/microkit/releases/download/1.3.0/microkit-sdk-1.3.0-linux-x86-64.tar.gz"
+    - label: "microkit-sdk-1.3.0-macos-x86-64.tar.gz"
+      url: "https://github.com/seL4/microkit/releases/download/1.3.0/microkit-sdk-1.3.0-macos-x86-64.tar.gz"
+    - label: "microkit-sdk-1.3.0-macos-aarch64.tar.gz"
+      url: "https://github.com/seL4/microkit/releases/download/1.3.0/microkit-sdk-1.3.0-macos-aarch64.tar.gz"

--- a/_includes/project-sidebar.html
+++ b/_includes/project-sidebar.html
@@ -83,6 +83,20 @@ Because of this we need to split the list into two before sorting.
 
 {% endif %}
 
+{% if project.sdk_downloads %}
+<h3>SDK downloads</h3>
+  {% for release in project.sdk_downloads %}
+    <h4>{{ release.version }}</h4>
+    {% for sdk in release.sdks %}
+      <li>
+          <a href="{{ sdk.url }}">
+              {{ sdk.label }}
+            </a>
+      </li>
+    {% endfor %}
+  {% endfor %}
+{% endif %}
+
 {% assign update_where_exp = "item.url contains '/updates/" | append: project.name | append: "/'" %}
 {% assign updates = site['updates'] | where_exp:"item", update_where_exp %}
 {% for update in updates | sort: "date" %}


### PR DESCRIPTION
Looks like this:

![Screenshot from 2024-07-01 18 28 12](https://github.com/seL4/docs/assets/10481259/72dd24eb-f8e6-48bf-a663-d58168e1cc15)

Didn't know if there was a better way of dealing with a custom field in the project YAML file.

Draft since these URLs don't exist yet.