### PR TITLE
clean up release sidebar

### DIFF
--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -135,7 +135,7 @@ starting from scratch on a new platform port.
 | - | - | - | - | - | - | - | - | - |
 {%- assign sorted = site.pages | sort: 'platform'%}
 {% for page in sorted %}
-{%- if page.arm_hardware and page.Maintained == "No"" -%}
+{%- if page.arm_hardware and page.Maintained == "No" -%}
 | <span style="color:grey">[{{ page.platform }}]({{page.url}})</span> (**unmaintained**) | <span style="color:grey">{{ page.soc}}</span> | <span style="color:grey">{{ page.cpu }}</span> | <span style="color:grey">{{ page.arch }}</span> | <span style="color:grey">{{ page.virtualization }}</span> | <span style="color:grey">{{ page.iommu}}</span> | <span style="color:grey">{{ page.Status }}</span> | <span style="color:grey">{{ page.Contrib }}</span> |
 {% endif %}
 {%- endfor %}

--- a/_includes/project-sidebar.html
+++ b/_includes/project-sidebar.html
@@ -53,9 +53,9 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 Sort sorts by string sorting so a version of 2.3.0 is higher than 10.0.0.
 Because of this we need to split the list into two before sorting.
 {% endcomment %}
-{% assign releases_1 = releases | where_exp:"item", "item.version_digits != 2" | sort: "version"  %}
+{% assign releases_1 = releases | where_exp:"item", "item.version_digits != 2" | sort: "version" %}
 {% assign releases_2 = releases | where_exp:"item", "item.version_digits == 2" | sort: "version" %}
-{% assign releases =  releases_1 | concat: releases_2 %}
+{% assign releases =  releases_1 | concat: releases_2 | reverse %}
 {% if project.name != 'sel4' %}
   {% for release in releases %}
       {% if forloop.first == true %}

--- a/_includes/project-sidebar.html
+++ b/_includes/project-sidebar.html
@@ -69,9 +69,7 @@ Because of this we need to split the list into two before sorting.
   {% endfor %}
 {% else %}
 <h3>Releases</h3>
-<h4> Master (verified kernel) </h4>
-
-{% for release in releases  %}
+{% for release in releases %}
     {% if release.variant != "mcs" %}
       <li>
         <a style="{% if release.url == page.url %} font-weight: bold; {%endif%}" href="{{ release.url }}">
@@ -79,21 +77,6 @@ Because of this we need to split the list into two before sorting.
         </a> (<a style="{% if release.url == page.url %} font-weight: bold; {%endif%}" href="http://sel4.systems/Info/Docs/seL4-manual-{{ release.version }}.pdf">manual</a>)
       </li>
 
-    {% endif %}
-
-{% endfor %}
-
-<h4>Experimental Branches</h4>
-
-We occasionally pre-release experimental branches for community feedback and availability.
-<h5>Mixed Criticality Support (MCS) / Realtime </h5>
-{% for release in releases  %}
-    {% if release.variant == "mcs" %}
-      <li>
-        <a style="{% if release.url == page.url %} font-weight: bold; {%endif%}" href="{{ release.url }}">
-          {{ release.title }}
-        </a> (<a style="{% if release.url == page.url %} font-weight: bold; {%endif%}" href="http://sel4.systems/Info/Docs/seL4-manual-{{ release.version }}.pdf">manual</a>)
-      </li>
     {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
- latest release on top
- remove mcs from side bar (confusing, and still available from other navigation)
- remove experimental seL4 branches from side bar, because there aren't any