### PR TITLE
Fix typos in Microkit 1.4.1 release notes

### DIFF
--- a/content_collections/_releases/microkit/1.4.1.md
+++ b/content_collections/_releases/microkit/1.4.1.md
@@ -19,9 +19,9 @@ This release contains various bug fixes. It does not include any new features.
 * Enabled FPU for QEMU RISC-V virt and Pine64 Star64.
   * libmicrokit builds with hardware floating point enabled and, while it does not use the FPU,
     it means that every object linked with libmicrokit must also build with hardware floating
-    point enabled. Previously using floating point operations would caused a crash in user-space.
+    point enabled. Previously using floating point operations would cause a crash in user-space.
 * Fixed the loader link address for the MaaXBoard.
-  * This does mean that if you target the MaaxBoard you will have to loader Microkit images at
+  * This does mean that if you target the MaaxBoard you will have to load Microkit images at
     a different address. See the manual for details.
 * Added error checking for overlapping memory regions.
 * Included every TCB register in the monitor logs when a fault occurs.


### PR DESCRIPTION
Given that people will probably refer to these in the future, it's worth fixing the typos.