### PR TITLE
Update some links to foundation website

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -71,7 +71,7 @@ on specifically configured platforms. These claims do not automatically
 transfer to other platforms, other seL4 configurations, or custom seL4
 versions. Please consult [Frequently Asked
 Questions](FrequentlyAskedQuestions), as well as the [proof and
-assumptions page](http://sel4.systems/Info/FAQ/proof.pml) for a better
+assumptions page](http://sel4.systems/Info/FAQ/proof.html) for a better
 understanding of the intersection of verification and seL4.
 
 ### Setting up your machine

--- a/projects/sel4/frequently-asked-questions.md
+++ b/projects/sel4/frequently-asked-questions.md
@@ -324,7 +324,7 @@ system is configured.
 
 For a more in-depth description, see the
 [proof and assumptions
-page](https://sel4.systems/Info/FAQ/proof.pml).
+page](https://sel4.systems/Info/FAQ/proof.html).
 
 ### How do I leverage seL4's formal proofs?
  The seL4 proofs are just

--- a/projects/sel4/kernel-contribution.md
+++ b/projects/sel4/kernel-contribution.md
@@ -213,4 +213,4 @@ If you are interested in proof contributions the main things to do are to:
 
 - [Learn](http://proofcraft.org/blog/proof-engineer-reading.html) about the [Isabelle theorem prover](http://isabelle.in.tum.de/).
 - Review the [proofs themselves](https://github.com/seL4/l4v/).
-- [Contact us](https://sel4.systems/contact/home.pml) to discuss the possibilities.
+- [Contact us](https://sel4.systems/contact/) to discuss the possibilities.

--- a/projects/sel4/verified-configurations.md
+++ b/projects/sel4/verified-configurations.md
@@ -24,7 +24,7 @@ currently constituting: ARM, ARM\_HYP, ARM\_MCS, AARCH64, RISCV64, RISCV64\_MCS,
 
 Please consult [Frequently Asked
 Questions](/FrequentlyAskedQuestions), as well as the [proof and
-assumptions page](http://sel4.systems/Info/FAQ/proof.pml) for a better
+assumptions page](http://sel4.systems/Info/FAQ/proof.html) for a better
 understanding of the intersection of verification and seL4.
 
 ## Examining and Building Verified Configurations


### PR DESCRIPTION
Some links to the seL4 Foundation website were broken when the website moved to GitHub pages.