### PR TITLE
add more verified platforms

### DIFF
--- a/Hardware/HiKey/index.md
+++ b/Hardware/HiKey/index.md
@@ -8,7 +8,7 @@ virtualization: ARM HYP
 iommu: "No"
 soc: Kirin 620
 cpu: Cortex-A53
-Status: Unverified
+Status: "[Verified](/projects/sel4/verified-configurations.html#hikey)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/JetsonTX2.md
+++ b/Hardware/JetsonTX2.md
@@ -9,7 +9,7 @@ virtualization: "Yes"
 iommu: "Yes"
 soc: NVIDIA Tegra X2
 cpu: Cortex-A57 Quad, Dual NVIDIA Denver
-Status: "FC complete, [Integrity ongoing](/projects/sel4/verified-configurations.html#aarch64)"
+Status: "[FC complete, Integrity ongoing](/projects/sel4/verified-configurations.html#aarch64)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/OdroidC2.md
+++ b/Hardware/OdroidC2.md
@@ -9,7 +9,7 @@ virtualization: "No"
 iommu: "No"
 soc: Amlogic S905
 cpu: Cortex-A53
-Status: Unverified
+Status: "[FC complete, Integrity ongoing](/projects/sel4/verified-configurations.html#odroidc2)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/OdroidC4.md
+++ b/Hardware/OdroidC4.md
@@ -9,7 +9,7 @@ virtualization: "Yes"
 iommu: "No"
 soc: Amlogic S905X3
 cpu: Cortex-A55
-Status: Unverified
+Status: "[FC complete, Integrity ongoing](/projects/sel4/verified-configurations.html#odroidc4)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/OdroidXU.md
+++ b/Hardware/OdroidXU.md
@@ -8,7 +8,7 @@ virtualization: ARM HYP
 iommu: limited SMMU
 soc: Exynos5
 cpu: Cortex-A15
-Status: Unverified
+Status: "[Verified](/projects/sel4/verified-configurations.html#arm_hyp-exynos-5)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/Rpi4.md
+++ b/Hardware/Rpi4.md
@@ -8,7 +8,7 @@ virtualization: ARM HYP
 iommu: "No"
 soc: BCM2711
 cpu: Cortex-A72
-Status: Unverified
+Status: "[FC complete, Integrity ongoing](/projects/sel4/verified-configurations.html#bcm2711)"
 Contrib: "[Hensoldt](https://hensoldt-cyber.com) and [ARM Research IceCap](https://gitlab.com/arm-research/security/icecap/icecap)"
 Maintained: "[Hensoldt](https://hensoldt-cyber.com)"
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/ZC706.md
+++ b/Hardware/ZC706.md
@@ -10,7 +10,7 @@ virtualization: "No"
 iommu: "No"
 soc: Zynq7000
 cpu: Cortex-A9
-Status: Unverified
+Status: "[Verified](/projects/sel4/verified-configurations.html#zynq7000)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/ZCU102.md
+++ b/Hardware/ZCU102.md
@@ -8,7 +8,7 @@ virtualization: ARM HYP
 iommu: SMMU
 soc: Zynq UltraScale+ MPSoC
 cpu: Cortex-A53
-Status: Unverified
+Status: "[FC complete, Integrity ongoing](/projects/sel4/verified-configurations.html#zynqmp)"
 Contrib: "[DornerWorks](https://dornerworks.com)"
 Maintained: "[DornerWorks](https://dornerworks.com)"
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/imx8mm.md
+++ b/Hardware/imx8mm.md
@@ -9,7 +9,7 @@ virtualization: "No"
 iommu: "No"
 soc: IMX8MM-EVK
 cpu: Cortex-A53 Quad 1.8 GHz
-Status: "[FC](/projects/sel4/verified-configurations.html#arm-imx8mm-evk)"
+Status: "[FC](/projects/sel4/verified-configurations.html#imx8mm)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/jetsontk1.md
+++ b/Hardware/jetsontk1.md
@@ -9,7 +9,7 @@ virtualization: ARM HYP
 iommu: SMMU
 soc: NVIDIA Tegra K1
 cpu: Cortex-A15
-Status: Unverified
+Status: "[Verified](/projects/sel4/verified-configurations.html#tk1)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Hardware/odroidx.md
+++ b/Hardware/odroidx.md
@@ -8,7 +8,7 @@ virtualization: "No"
 iommu: "No"
 soc: Exynos4412
 cpu: Cortex-A9
-Status: Unverified
+Status: "[Verified](/projects/sel4/verified-configurations.html#exynos4)"
 Contrib: Data61
 Maintained: seL4 Foundation
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ docker_build:
 # --host 0.0.0.0 serves on all interfaces, so that docker can export
 # the connection; also works locally
 serve: build
-	JEKYLL_ENV=$(JEKYLL_ENV) bundle exec jekyll serve --host 0.0.0.0
+	JEKYLL_ENV=$(JEKYLL_ENV) bundle exec jekyll serve
 
 build: generate_api ruby_deps $(REPOSITORIES)
 	$(MAKE) tutorials

--- a/projects/sel4/verified-configurations.md
+++ b/projects/sel4/verified-configurations.md
@@ -32,12 +32,19 @@ understanding of the intersection of verification and seL4.
 Current verified configurations can be found in seL4 sources in the
 `configs` folder:
 ```sh
-ls configs/*_verified.cmake
-# AARCH64_verified.cmake         ARM_verified.cmake
-# ARM_HYP_exynos5_verified.cmake RISCV64_MCS_verified.cmake
-# ARM_HYP_verified.cmake         RISCV64_verified.cmake
-# ARM_MCS_verified.cmake         X64_verified.cmake
-# ARM_imx8mm_verified.cmake
+cd configs/
+ls *_verified.cmake
+# AARCH64_bcm2711_verified.cmake    ARM_exynos5410_verified.cmake
+# AARCH64_hikey_verified.cmake      ARM_exynos5422_verified.cmake
+# AARCH64_odroidc2_verified.cmake   ARM_hikey_verified.cmake
+# AARCH64_odroidc4_verified.cmake   ARM_imx8mm_verified.cmake
+# AARCH64_verified.cmake            ARM_tk1_verified.cmake
+# AARCH64_zynqmp_verified.cmake     ARM_verified.cmake
+# ARM_HYP_exynos5410_verified.cmake ARM_zynq7000_verified.cmake
+# ARM_HYP_exynos5_verified.cmake    ARM_zynqmp_verified.cmake
+# ARM_HYP_verified.cmake            RISCV64_MCS_verified.cmake
+# ARM_MCS_verified.cmake            RISCV64_verified.cmake
+# ARM_exynos4_verified.cmake        X64_verified.cmake
 ```
 
 To obtain specific source code and build for a given configuration (e.g.
@@ -71,16 +78,75 @@ the [roadmap](/projects/roadmap.html) for status and upcoming features.
 ## ARM Sabre Lite
 
 | File | `ARM_verified.cmake`
-| Architecture | ARMv7
+| Architecture | ARMv7, 32 bit
 | Platform | i.MX 6 (Sabre Lite)
 | Floating-point support | No
 | Hypervisor mode | No
 | **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
 
+## ARM Exynos 4
+{: #exynos4}
+
+| File | `ARM_exynos4_verified.cmake`
+| Architecture | ARMv7, 32 bit
+| Platform | exynos4
+| Floating-point support | No
+| Hypervisor mode | No
+| **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
+
+## ARM Exynos 5
+
+| File | `ARM_exynos5410_verified.cmake` and `ARM_exynos5422_verified.cmake`
+| Architecture | ARMv7, 32 bit
+| Platform | exynos5410 and exynos5422
+| Floating-point support | No
+| Hypervisor mode | No
+| **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
+
+## ARM Hikey
+
+| File | `ARM_hikey_verified.cmake`
+| Architecture | ARMv7, 32 bit
+| Platform | hikey
+| Floating-point support | No
+| Hypervisor mode | No
+| **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
+
+## ARM TK1
+{: #tk1}
+
+| File | `ARM_tk1_verified.cmake`
+| Architecture | ARMv7, 32 bit
+| Platform | Jetson TK1
+| Floating-point support | No
+| Hypervisor mode | No
+| **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
+
+## ARM Zynq7000
+{: #zynq7000}
+
+| File | `ARM_zynq7000_verified.cmake`
+| Architecture | ARMv7, 32 bit
+| Platform | zynq7000
+| Floating-point support | No
+| Hypervisor mode | No
+| **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
+
+
+## ARM ZynqMP
+
+| File | `ARM_zynqmp_verified.cmake`
+| Architecture | ARMv7, 32 bit
+| Platform | zcu102 and zcu106 in 32 bit mode
+| Floating-point support | No
+| Hypervisor mode | No
+| **Verified properties** | functional correctness incl fast path, integrity (access control), confidentiality (information flow), binary correctness (covers all verified C code), user-level system initialisation
+
 ## ARM IMX8MM-EVK
+{: #imx8mm}
 
 | File | `ARM_imx8mm_verified.cmake`
-| Architecture | ARMv7
+| Architecture | ARMv7, 32 bit
 | Platform | IMX8MM-EVK
 | Floating-point support | Yes
 | Hypervisor mode | No
@@ -89,7 +155,7 @@ the [roadmap](/projects/roadmap.html) for status and upcoming features.
 ## ARM\_HYP TK1
 
 File | `ARM_HYP_verified.cmake`
-Architecture | ARMv7
+Architecture | ARMv7, 32 bit
 Platform | Tegra TK1
 Floating-point support | No
 Hypervisor mode | Yes
@@ -97,17 +163,17 @@ Hypervisor mode | Yes
 
 ## ARM\_HYP Exynos5
 
-File | `ARM_HYP_exynos5_verified.cmake`
-Architecture | ARMv7
+File | `ARM_HYP_exynos5_verified.cmake` and `ARM_HYP_exynos5410_verified.cmake`
+Architecture | ARMv7, 32 bit
 Platform | Odroid XU4
 Floating-point support | No
 Hypervisor mode | Yes
 **Verified properties** | functional correctness, incl fast path
 
-## ARM_MCS
+## ARM\_MCS
 
 File | `ARM_MCS_verified.cmake`
-Architecture | ARMv7
+Architecture | ARMv7, 32 bit
 Platform | i.MX 6 (Sabre Lite)
 Floating-point support | No
 Hypervisor mode | No
@@ -117,8 +183,58 @@ Mixed-Criticality-Systems API | Yes
 ## AARCH64
 
 | File | `AARCH64_verified.cmake`
-| Architecture | ARMv8
+| Architecture | ARMv8, 64 bit
 | Platform | Tegra X2 (Jetson TX2)
+| Floating-point support | Yes
+| Hypervisor mode | Yes
+| **Verified properties** | functional correctness, incl fast path completed; integrity proof in progress
+
+## AARCH64 RPI4
+{: #bcm2711}
+
+| File | `AARCH64_bcm2711_verified.cmake`
+| Architecture | ARMv8, 64 bit
+| Platform | bcm2711 (Raspberry PI 4)
+| Floating-point support | Yes
+| Hypervisor mode | Yes
+| **Verified properties** | functional correctness, incl fast path completed; integrity proof in progress
+
+## AARCH64 Hikey
+{: #hikey}
+
+| File | `AARCH64_hikey_verified.cmake`
+| Architecture | ARMv8, 64 bit
+| Platform | hikey
+| Floating-point support | Yes
+| Hypervisor mode | Yes
+| **Verified properties** | functional correctness, incl fast path completed; integrity proof in progress
+
+## AARCH64 Odroid C2
+{: #odroidc2}
+
+| File | `AARCH64_odroidc2_verified.cmake`
+| Architecture | ARMv8, 64 bit
+| Platform | odroidc2
+| Floating-point support | Yes
+| Hypervisor mode | Yes
+| **Verified properties** | functional correctness, incl fast path completed; integrity proof in progress
+
+## AARCH64 Odroid C4
+{: #odroidc4}
+
+| File | `AARCH64_odroidc4_verified.cmake`
+| Architecture | ARMv8, 64 bit
+| Platform | odroidc4
+| Floating-point support | Yes
+| Hypervisor mode | Yes
+| **Verified properties** | functional correctness, incl fast path completed; integrity proof in progress
+
+## AARCH64 ZynqMP
+{: #zynqmp}
+
+| File | `AARCH64_zynqmp_verified.cmake`
+| Architecture | ARMv8, 64 bit
+| Platform | zynqmp (zcu102 and zcu106)
 | Floating-point support | Yes
 | Hypervisor mode | Yes
 | **Verified properties** | functional correctness, incl fast path completed; integrity proof in progress
@@ -132,7 +248,7 @@ Floating-point support | No
 Hypervisor mode | No
 **Verified properties** | functional correctness, integrity (access control), confidentiality (information flow); verification of fast path in progress
 
-## RISCV64_MCS
+## RISCV64\_MCS
 
 File | `RISCV64_MCS_verified.cmake`
 Architecture | RISC-V 64-bit


### PR DESCRIPTION
Adding the verified platforms that are merged (not yet the ones in https://github.com/seL4/seL4/pull/1373).

The way these are presented makes less sense the more platforms we add, but for now this should still be Ok. We'll be working on reorganising that in the docsite refresh.