### PR TITLE
github: bump runner OS version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: Site
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -45,7 +45,7 @@ jobs:
             github.event_name == 'workflow_dispatch') }}
     needs: build
     name: 'Deploy'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.linkcheck-ignore.yml
+++ b/.linkcheck-ignore.yml
@@ -1,0 +1,17 @@
+# Copyright 2025 Proofcraft Pty Ltd
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Ignore all files that are part of the website itself, they will get their own
+# link check. Only put admin files such as README.md into the standard PR check.
+files:
+  - vendor
+  - "_.*/.*"
+  - ".*html"
+  - ".*/.*/.*md"
+  - CommunityProjects.md
+  - SuggestedProjects.md
+  - MaintainedRepositories.md
+  - Resources.md
+  - index.md
+
+urls:


### PR DESCRIPTION
20.04 is no longer supported. Python and ruby version remain pinned.