### PR TITLE
Provide hw-info for PC99 and explain simulation targets

### DIFF
--- a/Hardware/X64.md
+++ b/Hardware/X64.md
@@ -1,12 +1,13 @@
 ---
-cmake_plat: ia32
+cmake_plat: x64
 simulation_target: true
 simulation_only: false
-arch: x86
+arch: x64
 platform: PC99
 virtualization: true
 iommu: true
-Status: Unverified
+Status: FC (without VT-X, VT-D and fastpath)
+verified: x64
 Contrib: "Data61"
 Maintained: "seL4 Foundation"
 parent: /Hardware/
@@ -14,6 +15,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 ---
 
-# PC99 (32-bit)
+# PC99 (64-bit)
 
 {% include pc99.md %}

--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -139,8 +139,8 @@ seL4 supports PC99-style Intel Architecture Platforms.
 
 | Platform              | Arch | Virtualisation | IOMMU | Verification Status                  |
 | -                     |  -   | -              | -     | -                                    |
-| [PC99 (32-bit)](IA32.html) | x86  | VT-X           | VT-D  | Unverified                        |
-| [PC99 (64-bit)](IA32.html) | x64  | VT-X           | VT-D  | [FC (without VT-X, VT-D and fastpath)][X64] |
+| [PC99 (32-bit)](IA32.html) | x86  | VT-X      | VT-D  | Unverified                        |
+| [PC99 (64-bit)](X64.html)  | x64  | VT-X      | VT-D  | [FC (without VT-X, VT-D and fastpath)][X64] |
 
 [X64]: {{ '/projects/sel4/verified-configurations.html#x64' | relative_url }}
 

--- a/Hardware/index.md
+++ b/Hardware/index.md
@@ -151,7 +151,11 @@ Running seL4 in a simulator is a quick way to test it out and iteratively
 develop software. Note that feature support is then limited by the simulator.
 See the QEMU [Arm](qemu-arm-virt.html) and [RISCV](qemu-riscv-virt.html) targets
 and the [simulation instructions for sel4test](../projects/sel4test/#running-it)
-for x86 for how to run seL4 using QEMU.
+for x86 for how to run seL4 using QEMU. Some hardware platforms support the
+`SIMULATION=1` option --- this will be marked on the respective platform page
+and will generally be good enough to run most of the seL4 test suite, but QEMU
+usually does not provide enough hardware device implementation to build more
+complex systems in the simulated environment.
 
 ### Not in the lists above?
 

--- a/_includes/hw-info.html
+++ b/_includes/hw-info.html
@@ -36,7 +36,12 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 </td>
 </tr>
 <tr>
-<td>seL4 SMMU support</td>
+{%- if page.platform == "PC99" %}
+{%- assign SMMU = "IOMMU (VT-d)" %}
+{%- else %}
+{%- assign SMMU = "SMMU" %}
+{%- endif %}
+<td>seL4 {{SMMU}} support</td>
 <td>
 {%- if page.iommu %}
 {%-   if page.iommu == "limited" %}

--- a/_includes/pc99.md
+++ b/_includes/pc99.md
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
 This text is shared between ia32 and x64
 {%- endcomment %}
 
-seL4 runs on 32-bit ia32 and 64-bit x64 machines, on qemu and on hardware.
+seL4 runs on 32-bit ia32 and 64-bit x64 machines, on QEMU and on hardware.
 
 {% include hw-info.html %}
 

--- a/_includes/pc99.md
+++ b/_includes/pc99.md
@@ -1,0 +1,77 @@
+{%- comment %}
+SPDX-License-Identifier: CC-BY-SA-4.0
+SPDX-FileCopyrightText: 2020 seL4 Project a Series of LF Projects, LLC.
+
+This text is shared between ia32 and x64
+{%- endcomment %}
+
+seL4 runs on 32-bit ia32 and 64-bit x64 machines, on qemu and on hardware.
+
+{% include hw-info.html %}
+
+## Simulation
+
+{% include sel4test.md %}
+
+## Real Hardware
+
+When running on real hardware console output will be over serial. You will need
+to plug a serial cable into your machine to see any output.
+
+The build system produces a multiboot compliant image for x86; a grub2
+stanza is here, but we usually boot via PXE for convenience.
+
+```
+menuentry "Load seL4 VM" --class os {
+    load_video
+    insmod gzio
+    insmod part_msdos
+    insmod ext2
+    set root='(hd0,msdos2)'
+    multiboot /boot/sel4kernel
+    module /boot/sel4rootserver
+}
+```
+
+Booting via PXEBOOT using
+[syslinux PXELINUX](http://www.syslinux.org/wiki/index.php?title=PXELINUX) requires setting up a tftp and dhcp server on the network
+that the machine you want to boot is connected to. The
+[syslinux](http://www.syslinux.org/wiki/index.php?title=Download)
+site has a download for pxelinux which we load over PXEBOOT
+that then can load seL4. The configuration for pxelinux.cfg/default is
+provided below.
+
+```
+label seL4
+        kernel mboot.32
+        append kernel-{{ page.cmake_plat }}-pc99 --- apps-{{ page.cmake_plat }}-pc99
+```
+
+## Booting off USB with syslinux
+
+Use syslinux to create a bootable USB stick as follows.
+
+Assuming your USB flash drive is at `/dev/sdb` with a FAT partition at
+`/dev/sdb1`:
+
+```bash
+install-mbr /dev/sdb
+syslinux --install /dev/sdb1
+mount /dev/sdb1 /mnt
+cp images/sel4test-driver-image-{{ page.cmake_plat }}-pc99 /mnt/rootserver
+cp images/kernel-{{ page.cmake_plat }}-pc99 /mnt/sel4kernel
+cat > /mnt/syslinux.cfg <<EOF
+SERIAL 0 115200
+DEFAULT seL4test
+LABEL seL4test
+    kernel mboot.c32
+    append sel4kernel --- rootserver
+EOF
+cp /usr/lib/syslinux/modules/bios/mboot.c32 /mnt
+cp /usr/lib/syslinux/modules/bios/libcom32.c32 /mnt
+umount /mnt
+```
+
+Use `fdisk` to make sure the first partition is bootable.
+
+And you're done. Output will come on the serial port


### PR DESCRIPTION
- split up the IA32 page into one for ia32 and one for x64 (same included text, but different hardware info settings)
- adjust hw-info accordingly for IOMMU vs SMMU
- set expectations for simulation target platforms in the simulation section

I think this should close #243 -- we now do have info for each platform page (including pc99), and including it in the hardware table would give the wrong impression that these platforms provide a full simulation environment. The new explanation bit in the simulation section hopefully explains that part.