### PR TITLE
copy button: narrower CSS selector

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -27,7 +27,7 @@
 })();
 
 (function initCopyButtons() {
-  const codeBlocks = document.querySelectorAll('div > pre > code');
+  const codeBlocks = document.querySelectorAll('div.highlight > pre:first-child > code:first-child');
 
   for (let codeBlock of codeBlocks) {
     preBlock = codeBlock.parentElement;


### PR DESCRIPTION
Code highlight blocks have the form

```
<div class="higlight"><pre><code>...
```

(wrapped in another div that specifies the language). The copy-button insertion relies on the presence of the `<div>`. The previous CSS selector was too loose for that, it allowed the `<pre>` to be a direct descendant of any `<div>` at any position, so it could be

```
<div> <p>..</p> etc <pre><code>
```

which does happen when the syntax highlighter does not recognise the language that is passed in from the code block (```lang). This leads to mis-styling of the copy buttons, in particular, the position will be relative to the wrapping div, which might be anywhere (usually the page container), and consequently the hover group for showing the copy buttons may also be the page container.

Making the selector narrow means only code blocks with recognised language will have a copy button.
