### PR TITLE
zc706: remove outdated instructions

### DIFF
--- a/Hardware/ZC706.md
+++ b/Hardware/ZC706.md
@@ -94,5 +94,5 @@ You will need
 
 2. Run XMD. XMD will not terminate; leave it open.
 3. Next run GDB. Any arm-*-gdb should work.
-4. Enter "tar ext localhost:1234" to connect to the GDB server that was started by XMD or the hw_server
+4. Enter "target extended-remote localhost:1234" to connect to the GDB server that was started by XMD or the hw_server
 5. "c" to start the program!

--- a/Hardware/ZC706.md
+++ b/Hardware/ZC706.md
@@ -34,131 +34,12 @@ Xilinx maintains [online material](https://www.amd.com/en/products/adaptive-socs
 
 {% include sel4test.md %}
 
-## U-Boot
-
-Use the following patch to set up an appropriate u-boot environment and enable elf loading:
-
-```patch
-From 8fb3caeb735b7cb6be409842a3e130a8a4173ad3 Mon Sep 17 00:00:00 2001
-From: Adrian Herrera <adrian.herrera@dsto.defence.gov.au>
-Date: Wed, 5 Nov 2014 09:58:00 +1030
-Subject: [PATCH] Added Zynq ZC70x board for seL4
-
-Currently only boots from a FAT-formatted SD card; so no network boot yet
----
- boards.cfg                        |  1 +
- include/configs/zynq_zc70x_sel4.h | 60 +++++++++++++++++++++++++++++++++++++++
- 2 files changed, 61 insertions(+)
- create mode 100644 include/configs/zynq_zc70x_sel4.h
-
-diff --git a/boards.cfg b/boards.cfg
-index 7beb3c8..960b374 100644
---- a/boards.cfg
-+++ b/boards.cfg
-@@ -384,6 +384,7 @@ Active  arm         armv7          u8500       st-ericsson     u8500
- Active  arm         armv7          vf610       freescale       vf610twr            vf610twr                              vf610twr:IMX_CONFIG=board/freescale/vf610twr/imximage.cfg                                                                         Alison Wang <b18965@freescale.com>
- Active  arm         armv7          zynq        xilinx          zynq                zynq_microzed                        -                                                                                                                                  Michal Simek <monstr@monstr.eu>:Jagannadha Sutradharudu Teki <jaganna@xilinx.com>
- Active  arm         armv7          zynq        xilinx          zynq                zynq_zc70x                           -                                                                                                                                  Michal Simek <monstr@monstr.eu>:Jagannadha Sutradharudu Teki <jaganna@xilinx.com>
-+Active  arm         armv7          zynq        xilinx          zynq                zynq_zc70x_sel4                      -                                                                                                                                  Adrian Herrera <adrian.herrera@dsto.defence.gov.au>
- Active  arm         armv7          zynq        xilinx          zynq                zynq_zc770_XM010                     zynq_zc770:ZC770_XM010                                                                                                             Michal Simek <monstr@monstr.eu>:Jagannadha Sutradharudu Teki <jaganna@xilinx.com>
- Active  arm         armv7          zynq        xilinx          zynq                zynq_zc770_XM011                     zynq_zc770:ZC770_XM011                                                                                                             Michal Simek <michal.simek@xilinx.com>
- Active  arm         armv7          zynq        xilinx          zynq                zynq_zc770_XM012                     zynq_zc770:ZC770_XM012                                                                                                             Michal Simek <monstr@monstr.eu>:Jagannadha Sutradharudu Teki <jaganna@xilinx.com>
-diff --git a/include/configs/zynq_zc70x_sel4.h b/include/configs/zynq_zc70x_sel4.h
-new file mode 100644
-index 0000000..f8bbac5
---- /dev/null
-+++ b/include/configs/zynq_zc70x_sel4.h
-@@ -0,0 +1,60 @@
-+/*
-+ * (C) Copyright 2013 Xilinx, Inc.
-+ *
-+ * Configuration settings for the Xilinx Zynq ZC702 and ZC706 boards
-+ * See zynq-common.h for Zynq common configs
-+ *
-+ * SPDX-License-Identifier:	GPL-2.0-or-later
-+ */
-+
-+#ifndef __CONFIG_ZYNQ_ZC70X_SEL4_H
-+#define __CONFIG_ZYNQ_ZC70X_SEL4_H
-+
-+#define CONFIG_SYS_SDRAM_SIZE		(1024 * 1024 * 1024)
-+
-+#define CONFIG_ZYNQ_SERIAL_UART1
-+#define CONFIG_ZYNQ_GEM0
-+#define CONFIG_ZYNQ_GEM_PHY_ADDR0	7
-+
-+#define CONFIG_SYS_NO_FLASH
-+
-+#define CONFIG_ZYNQ_SDHCI0
-+#define CONFIG_ZYNQ_USB
-+#define CONFIG_ZYNQ_QSPI
-+#define CONFIG_ZYNQ_I2C0
-+#define CONFIG_ZYNQ_EEPROM
-+
-+#include <configs/zynq-common.h>
-+
-+/* Enable boot from ELF image */
-+#define CONFIG_CMD_ELF
-+
-+/* U-Boot prompt */
-+#if defined(CONFIG_SYS_PROMPT)
-+#undef CONFIG_SYS_PROMPT
-+#endif
-+
-+#define CONFIG_SYS_PROMPT    "zynq-seL4-uboot > "
-+
-+/* Default environment */
-+#if defined(CONFIG_EXTRA_ENV_SETTINGS)
-+#undef CONFIG_EXTRA_ENV_SETTINGS
-+#endif
-+
-+#define CONFIG_EXTRA_ENV_SETTINGS                                           \
-+    "ethaddr=00:0a:35:00:01:22\0"                                           \
-+    "bitstream_image=system.bit.bin\0"                                      \
-+    "boot_image=BOOT.bin\0"                                                 \
-+    "loadbit_addr=0x100000\0"                                               \
-+    "mmc_loadbit_fat=echo Loading bitstream from SD/MMC/eMMC to RAM...;"    \
-+        "mmcinfo && "                                                       \
-+        "fatload mmc 0 ${loadbit_addr} ${bitstream_image} && "              \
-+        "fpga load 0 ${loadbit_addr} ${filesize}\0"                         \
-+    "sel4_image=sel4/sel4-image\0"                                          \
-+    "loadsel4_addr=0x2080000\0"                                             \
-+    "sdboot=echo Loading seL4 image from SD/MMC/eMMC to RAM...;"            \
-+        "mmcinfo && "                                                       \
-+        "fatload mmc 0 ${loadsel4_addr} ${sel4_image} && "                  \
-+        "bootelf ${loadsel4_addr}\0"
-+
-+#endif /* __CONFIG_ZYNQ_ZC70X_SEL4_H */
---
-1.9.1
-```
-
-To get U-boot:
-
-```bash
-git clone https://github.com/xilinx/u-boot-xlnx.git
-cd u-boot-xlnx.git
-patch -p1 < 0001-Added-Zynq-ZC70x-board-for-seL4.patch
-export CROSS_COMPILE=arm-linux-gnueabi-
-make zynq_zc70x_sel4_config
-make
-```
-
-The u-boot file cannot be booted directly. You must first generate a boot image:
-
-```bash
-cp u-boot u-boot.elf
-echo "image: { $PWD/u-boot.elf }" > boot.bif
-/opt/Xilinx/SDK/2014.4/bin/bootgen -o BOOT.BIN -w -image image.bif
-```
-
-To boot from the SD card, make sure that the first partition of the SD card is FAT32 and copy BOOT.bin to the root directory.
 
 ## Development environment
 
 ### Vivado SDK
 
-Bitstream generation (ie FPGA code compiler) is not support for ZC706 when using a free license. Other features may still work
+Bitstream generation (ie FPGA code compiler) is not supported for ZC706 when using a free license. Other features may still work
 
 The Vivado SDK provides many features:
 
@@ -188,33 +69,30 @@ sudo ./install_drivers
 
 [http://wiki.gentoo.org/wiki/Xilinx_USB_JTAG_Programmers](http://wiki.gentoo.org/wiki/Xilinx_USB_JTAG_Programmers)
 
-#### You will need:
+You will need
 
 - xmd (shipped with vivado but can possibly be obtained as a package on its own)
 - digilent USB drivers
 
 1. create a xmd.ini script within the directory that you intend to run xmd from.
-```bash
-  # Connect to the board
-  connect arm hw
-  # program the fpga with the provided bitstream
-  fpga -f system_wrapper.bit
-  # The processor needs to be initialised (Clocks, MIO, etc), but these depend on the bitstream! ps7_init.tcl was generated with the bitstream. Load and execute this script to configure the processor.
-  source ps7_init.tcl
-  ps7_init
-  ps7_post_config
-  # Download your elf file (Could also be done from GDB)
-  dow bootimg.elf
-  # To run the elf file directly from XMD, uncomment the following lines
-  # run
-  # exit
-```
-2. Run XMD. On my system, the executable is: '/opt/Xilinx/SDK/2013.4/bin/lin64/xmd'. XMD will not terminate; leave it open.
-3. Next run GDB. On my system, the executable is: '/opt/Xilinx/SDK/2013.4/gnu/arm/lin/bin/arm-xilinx-eabi-gdb bootimg.elf', but any arm-*-gdb should work
-4. enter "tar ext localhost:1234" to connect to the GDB server that was started by XMD or the hw_server
+
+   ```bash
+     # Connect to the board
+     connect arm hw
+     # program the fpga with the provided bitstream
+     fpga -f system_wrapper.bit
+     # The processor needs to be initialised (Clocks, MIO, etc), but these depend on the bitstream! ps7_init.tcl was generated with the bitstream. Load and execute this script to configure the processor.
+     source ps7_init.tcl
+     ps7_init
+     ps7_post_config
+     # Download your elf file (Could also be done from GDB)
+     dow bootimg.elf
+     # To run the elf file directly from XMD, uncomment the following lines
+     # run
+     # exit
+   ```
+
+2. Run XMD. XMD will not terminate; leave it open.
+3. Next run GDB. Any arm-*-gdb should work.
+4. Enter "tar ext localhost:1234" to connect to the GDB server that was started by XMD or the hw_server
 5. "c" to start the program!
-
-Version 2013.4 of GDB throws an error about an inaccessible memory address. This is fixed in version 2014.4 of the tools, but also requires 2014.4 of XMD of hw_server.
-
-
-


### PR DESCRIPTION
According to #237 it is likely that current U-Boot works without patch. In any case the current instructions do not work, because the given patch does not apply any more.