### PR TITLE
hardware: fix rpi3 cmake platform string

### DIFF
--- a/Hardware/Rpi3.md
+++ b/Hardware/Rpi3.md
@@ -1,6 +1,6 @@
 ---
 arm_hardware: true
-cmake_plat: rpi3
+cmake_plat: bcm2837
 xcompiler_arg: -DAARCH32=1
 platform: Raspberry Pi 3-b
 arch: ARMv8A


### PR DESCRIPTION
`cmake_plat` wasn't shown on the old docsite, so there might be more typos of this kind around.

Would be nice to check these automatically at some point, but for now let's fix what we see.